### PR TITLE
Dark mode & Background

### DIFF
--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -37,11 +37,11 @@ const Navbar: React.FC = () => {
   };
 
   return (
-    <header className="navbar absolute text-warmscale-5 dark:text-lightscale-3 top-0 left-0 w-full px-5 z-50 flex items-center ">
+    <header className="navbar absolute text-lightmode-secondary dark:text-darkmode-secondary top-0 left-0 w-full px-5 z-50 flex transition duration-500 items-center ">
       <div className="flex-1 ">
         <a
           href="/"
-          className="font-semibold text-xl max-md:text-base hover:text-white dark:hover:text-tf-orange hover:cursor-pointer">
+          className="font-semibold text-xl max-md:text-base hover:text-darkmode-tertiary dark:hover:text-lightmode-tertiary transition duration-300 hover:cursor-pointer">
           wrapped.tf
           <div className="text-xs text-warmscale-1 dark:text-lightscale-7 -mt-1">by more.tf</div>
         </a>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -58,76 +58,76 @@ const Home: React.FC = () => {
   return (
     <div className="h-screen snap-start flex items-center justify-center">
       {/* Global Info */}
-      <div className="flex flex-col h-screen w-full snap-start items-center md:justify-center max-md:justify-start bg-topo-light bg-cover bg-center dark:bg-topo-dark bg-lightscale-3 dark:bg-warmscale-7 md:p-8 max-md:p-3 max-md:pt-20">
+      <div className="flex flex-col h-screen w-full snap-start items-center md:justify-center max-md:justify-start bg-topo-light bg-cover bg-center transition duration-500 dark:bg-topo-dark bg-lightscale-3 dark:bg-warmscale-7 md:p-8 max-md:p-3 max-md:pt-20">
         <div className="max-xl:h-[70vh] max-h-full flex flex-col justify-center items-center max-md:mt-5 max-xl:w-full xl:w-1/2 xl:h-4/6 font-londrina">
           {/* Section Header */}
-          <div className="w-full h-fit flex items-baseline text-lightmode-primary dark:text-darkmode-primary font-extrabold">
+          <div className="w-full h-fit flex items-baseline text-lightmode-primary transition duration-500 dark:text-darkmode-primary font-extrabold">
             <div className="text-4xl mx-2">2024 Wrapped!</div>
-            <div className="h-[2px] flex-grow bg-lightmode-primary dark:bg-darkmode-primary rounded-sm"></div>
+            <div className="h-[2px] flex-grow bg-lightmode-primary transition duration-500 dark:bg-darkmode-primary rounded-sm"></div>
           </div>
 
           <div className="w-full h-full grid grid-rows-3 gap-2 mb-4 max-md:mt-4 px-8">
             <div className="w-full h-full grid grid-cols-2 gap-2">
-                <div className="md:my-2 md:p-3 max-md:px-2 flex flex-col justify-center items-center w-full h-full backdrop-blur border-2 border-lightscale-5 dark:border-warmscale-6 rounded-tl-3xl rounded-br-lg rounded-tr-3xl rounded-bl-3xl">
-                    <div className="text-lightmode-secondary dark:text-darkmode-secondary md:text-3xl max-md:text-xl">TOTAL KILLS</div>
-                    <div className="text-lightmode-primary dark:text-darkmode-primary md:text-5xl  max-md:text-3xl">
+                <div className="md:my-2 md:p-3 max-md:px-2 flex flex-col justify-center items-center w-full h-full backdrop-blur border-2 border-lightscale-5 transition duration-500 dark:border-warmscale-6 rounded-tl-3xl rounded-br-lg rounded-tr-3xl rounded-bl-3xl">
+                    <div className="text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary md:text-3xl max-md:text-xl">TOTAL KILLS</div>
+                    <div className="text-lightmode-primary transition duration-500 dark:text-darkmode-primary md:text-5xl  max-md:text-3xl">
                         <CountUp start={0} end={61351245} duration={1.5} separator="," />
                     </div>
-                    <div className="text-lightmode-tertiary dark:text-darkmode-tertiary md:text-lg  max-md:text-base">Unprecedented bloodshed...</div>
+                    <div className="text-lightmode-tertiary transition duration-500 dark:text-darkmode-tertiary md:text-lg  max-md:text-base">Unprecedented bloodshed...</div>
                 </div>
-                <div className="md:my-2 md:p-3 max-md:px-2 flex flex-col justify-center items-center w-full h-full backdrop-blur border-2 border-lightscale-5 dark:border-warmscale-6  rounded-tl-3xl rounded-br-3xl rounded-tr-3xl rounded-bl-lg">
-                    <div className="text-lightmode-secondary dark:text-darkmode-secondary md:text-3xl max-md:text-xl">HOURS PLAYED</div>
-                    <div className="text-lightmode-primary dark:text-darkmode-primary md:text-5xl  max-md:text-3xl">
+                <div className="md:my-2 md:p-3 max-md:px-2 flex flex-col justify-center items-center w-full h-full backdrop-blur border-2 border-lightscale-5 transition duration-500 dark:border-warmscale-6  rounded-tl-3xl rounded-br-3xl rounded-tr-3xl rounded-bl-lg">
+                    <div className="text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary md:text-3xl max-md:text-xl">HOURS PLAYED</div>
+                    <div className="text-lightmode-primary transition duration-500 dark:text-darkmode-primary md:text-5xl  max-md:text-3xl">
                         <CountUp start={0} end={909969} duration={1.5} separator="," />
                     </div>
-                    <div className="text-lightmode-tertiary dark:text-darkmode-tertiary md:text-lg  max-md:text-base">Thats 104 years!</div>
+                    <div className="text-lightmode-tertiary transition duration-500 dark:text-darkmode-tertiary md:text-lg  max-md:text-base">Thats 104 years!</div>
                 </div>
             </div>
             <div className="w-full h-full grid grid-cols-3 gap-2">
-                <div className="md:my-2 md:p-3 max-md:px-2 flex flex-col justify-center items-center w-full h-full backdrop-blur border-2 border-lightscale-5 dark:border-warmscale-6  rounded-tl-3xl rounded-br-lg rounded-tr-lg rounded-bl-3xl">
-                    <div className="text-lightmode-secondary dark:text-darkmode-secondary md:text-3xl max-md:text-xl">PLAYERS</div>
-                    <div className="text-lightmode-primary dark:text-darkmode-primary md:text-5xl  max-md:text-3xl">
+                <div className="md:my-2 md:p-3 max-md:px-2 flex flex-col justify-center items-center w-full h-full backdrop-blur border-2 border-lightscale-5 transition duration-500 dark:border-warmscale-6  rounded-tl-3xl rounded-br-lg rounded-tr-lg rounded-bl-3xl">
+                    <div className="text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary md:text-3xl max-md:text-xl">PLAYERS</div>
+                    <div className="text-lightmode-primary transition duration-500 dark:text-darkmode-primary md:text-5xl  max-md:text-3xl">
                         <CountUp start={0} end={20963} duration={1.5} separator=","/>
                     </div>
-                    <div className="text-lightmode-tertiary dark:text-darkmode-tertiary md:text-lg  max-md:text-base"></div>
+                    <div className="text-lightmode-tertiary transition duration-500 dark:text-darkmode-tertiary md:text-lg  max-md:text-base"></div>
                 </div>
 
                 {/* Donut Chart Card */}
-                <div className="relative md:my-2 flex flex-col justify-center items-center w-full h-full backdrop-blur border-2 border-lightscale-5 dark:border-warmscale-6  rounded-tl-lg rounded-br-lg rounded-tr-lg rounded-bl-lg">
-                  <div className="text-lightmode-secondary dark:text-darkmode-secondary md:text-xl max-md:text-xs">MATCHES BY FORMAT</div>
+                <div className="relative md:my-2 flex flex-col justify-center items-center w-full h-full backdrop-blur border-2 border-lightscale-5 transition duration-500 dark:border-warmscale-6  rounded-tl-lg rounded-br-lg rounded-tr-lg rounded-bl-lg">
+                  <div className="text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary md:text-xl max-md:text-xs">MATCHES BY FORMAT</div>
                   <div className="flex justify-center items-center w-full h-full md:max-w-[200px] md:max-h-[100px] max-md:w-[100px] max-md:h-[110px] opacity-90">
                     <Doughnut data={data} options={options} />
                   </div>
                 </div>
                 
-                <div className="md:my-2 md:p-3 max-md:px-2 flex flex-col justify-center items-center w-full h-full backdrop-blur border-2 border-lightscale-5 dark:border-warmscale-6  rounded-tl-lg rounded-br-3xl rounded-tr-3xl rounded-bl-lg">
-                    <div className="text-lightmode-secondary dark:text-darkmode-secondary md:text-3xl max-md:text-xl">MATCHES</div>
-                    <div className="text-lightmode-primary dark:text-darkmode-primary md:text-5xl  max-md:text-3xl">
+                <div className="md:my-2 md:p-3 max-md:px-2 flex flex-col justify-center items-center w-full h-full backdrop-blur border-2 border-lightscale-5 transition duration-500 dark:border-warmscale-6  rounded-tl-lg rounded-br-3xl rounded-tr-3xl rounded-bl-lg">
+                    <div className="text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary md:text-3xl max-md:text-xl">MATCHES</div>
+                    <div className="text-lightmode-primary transition duration-500 dark:text-darkmode-primary md:text-5xl  max-md:text-3xl">
                         <CountUp start={0} end={200115} duration={1.5} separator=","/>
                     </div>
-                    <div className="text-lightmode-tertiary dark:text-darkmode-tertiary md:text-lg  max-md:text-base"></div>
+                    <div className="text-lightmode-tertiary transition duration-500 dark:text-darkmode-tertiary md:text-lg  max-md:text-base"></div>
                 </div>
             </div>
             <div className="w-full h-full grid grid-cols-2 gap-2">
-                <div className="md:my-2 md:p-3 max-md:px-2 flex flex-col justify-center items-center w-full h-full backdrop-blur border-2 border-lightscale-5 dark:border-warmscale-6  rounded-tl-3xl rounded-br-3xl rounded-tr-lg rounded-bl-3xl">
-                    <div className="text-lightmode-secondary dark:text-darkmode-secondary md:text-3xl max-md:text-xl">DAMAGE DEALT</div>
-                    <div className="text-lightmode-primary dark:text-darkmode-primary md:text-5xl  max-md:text-3xl">
+                <div className="md:my-2 md:p-3 max-md:px-2 flex flex-col justify-center items-center w-full h-full backdrop-blur border-2 border-lightscale-5 transition duration-500 dark:border-warmscale-6  rounded-tl-3xl rounded-br-3xl rounded-tr-lg rounded-bl-3xl">
+                    <div className="text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary md:text-3xl max-md:text-xl">DAMAGE DEALT</div>
+                    <div className="text-lightmode-primary transition duration-500 dark:text-darkmode-primary md:text-5xl  max-md:text-3xl">
                         <div className="md:hidden">8.6 Billion</div>
                         <CountUp start={0} end={8632980467} duration={1.5} separator="," className="max-md:hidden"/>
                     </div>
-                    <div className="text-lightmode-tertiary dark:text-darkmode-tertiary md:text-lg  max-md:text-base">YEEEOWCH!</div>
+                    <div className="text-lightmode-tertiary transition duration-500 dark:text-darkmode-tertiary md:text-lg  max-md:text-base">YEEEOWCH!</div>
                 </div>
-                <div className="md:my-2 md:p-3 max-md:px-2 flex flex-col justify-center items-center w-full h-full backdrop-blur border-2 border-lightscale-5 dark:border-warmscale-6  rounded-tl-lg rounded-br-3xl rounded-tr-3xl rounded-bl-3xl">
-                    <div className="text-lightmode-secondary dark:text-darkmode-secondary md:text-3xl max-md:text-xl">HEALING DONE</div>
-                    <div className="text-lightmode-primary dark:text-darkmode-primary md:text-5xl  max-md:text-3xl">
+                <div className="md:my-2 md:p-3 max-md:px-2 flex flex-col justify-center items-center w-full h-full backdrop-blur border-2 border-lightscale-5 transition duration-500 dark:border-warmscale-6  rounded-tl-lg rounded-br-3xl rounded-tr-3xl rounded-bl-3xl">
+                    <div className="text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary md:text-3xl max-md:text-xl">HEALING DONE</div>
+                    <div className="text-lightmode-primary transition duration-500 dark:text-darkmode-primary md:text-5xl  max-md:text-3xl">
                         <div className="md:hidden">19.1 Billion</div>
                         <CountUp start={0} end={19065346122} duration={1.5} separator="," className="max-md:hidden"/>
                     </div>
-                    <div className="text-lightmode-tertiary dark:text-darkmode-tertiary md:text-lg  max-md:text-base">What would we do without our medics?</div>
+                    <div className="text-lightmode-tertiary transition duration-500 dark:text-darkmode-tertiary md:text-lg  max-md:text-base">What would we do without our medics?</div>
                 </div>
             </div>
           </div>
-          <div className="h-[2px] w-full bg-lightmode-primary dark:bg-darkmode-primary rounded-sm"></div>
+          <div className="h-[2px] w-full bg-lightmode-primary transition duration-500 dark:bg-darkmode-primary rounded-sm"></div>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/Recap.tsx
+++ b/frontend/src/pages/Recap.tsx
@@ -1077,7 +1077,7 @@ const Recap: React.FC = () => {
       
       {/* Share */}
       <div className="flex flex-col h-screen w-full snap-start items-center justify-center md:p-8 max-md:p-3">
-        <section aria-labelledby="Share" className="max-xl:h-[70vh] max-h-full flex flex-col justify-center items-center  max-xl:w-full xl:w-2/3 xl:h-4/6 max-md:mb-20">
+        <section aria-labelledby="Share" className="max-xl:h-[70vh] max-h-full flex flex-col justify-center items-center  max-xl:w-full xl:w-2/3 xl:h-4/6 max-md:mb-20 font-londrina">
           <div className="w-full h-full md:h-1/2 md:w-1/2 flex flex-col justify-center items-center p-2">
             <div className="w-full h-fit flex justify-center items-baseline text-lightmode-primary transition duration-500 dark:text-darkmode-primary font-extrabold gap-4">
               <h2 id="Share" className="text-4xl mx-2 mb-3">Download & Share</h2></div>

--- a/frontend/src/pages/Recap.tsx
+++ b/frontend/src/pages/Recap.tsx
@@ -183,7 +183,7 @@ const Recap: React.FC = () => {
 
   if (loading) {
     return (
-      <div className="flex flex-col h-screen w-full snap-start items-center md:justify-center max-md:justify-start bg-topo-light bg-cover bg-center dark:bg-topo-dark bg-lightmode-background dark:bg-darkmode-background md:p-8 max-md:p-2 max-md:pt-20">
+      <div className="flex flex-col h-screen w-full snap-start items-center md:justify-center max-md:justify-start bg-topo-light bg-cover bg-center transition duration-500 dark:bg-topo-dark bg-lightmode-background dark:bg-darkmode-background md:p-8 max-md:p-2 max-md:pt-20">
         <span className="loading loading-spinner loading-sm"></span>
       </div>
     );
@@ -191,7 +191,7 @@ const Recap: React.FC = () => {
 
   if (error) {
     return (
-      <div className="flex flex-col h-screen w-full snap-start items-center md:justify-center max-md:justify-start bg-topo-light bg-cover bg-center dark:bg-topo-dark bg-lightmode-background dark:bg-darkmode-background md:p-8 max-md:p-2 max-md:pt-20">
+      <div className="flex flex-col h-screen w-full snap-start items-center md:justify-center max-md:justify-start bg-topo-light bg-cover bg-center transition duration-500 dark:bg-topo-dark bg-lightmode-background dark:bg-darkmode-background md:p-8 max-md:p-2 max-md:pt-20">
         <div className="text-error text-3xl font-londrina">{error}</div>
         <div className="text-error text-4xl font-londrina">please try refreshing</div>
       </div>
@@ -200,25 +200,25 @@ const Recap: React.FC = () => {
 
   if (profileData?.general.length === 0) {
     return (
-      <div className="flex flex-col h-screen w-full snap-start items-center md:justify-center max-md:justify-start bg-topo-light bg-cover bg-center dark:bg-topo-dark bg-lightmode-background dark:bg-darkmode-background md:p-8 max-md:p-2 max-md:pt-20">
+      <div className="flex flex-col h-screen w-full snap-start items-center md:justify-center max-md:justify-start bg-topo-light bg-cover bg-center transition duration-500 dark:bg-topo-dark bg-lightmode-background dark:bg-darkmode-background md:p-8 max-md:p-2 max-md:pt-20">
         <div className="text-error text-4xl font-londrina">NO GAMES IN 2024</div>
-        <a href="/" className="btn bg-lightmode-background dark:bg-darkmode-background text-lightmode-primary dark:text-darkmode-primary border-lightmode-border dark:border-darkmode-border">View Global Stats Here</a>
+        <a href="/" className="btn bg-lightmode-background transition duration-500 dark:bg-darkmode-background text-lightmode-primary dark:text-darkmode-primary border-lightmode-border dark:border-darkmode-border">View Global Stats Here</a>
       </div>
     );
   }
 
   return (
-    <main className="h-screen w-screen snap-y snap-mandatory overflow-y-scroll ">
+    <main className="h-screen w-screen snap-y snap-mandatory overflow-y-scroll bg-topo-light transition-all duration-500 dark:bg-topo-dark bg-cover bg-center bg-lightmode-background dark:bg-darkmode-background">
       {/* Overview */}
-      <div className="flex flex-col h-screen w-full snap-start items-center md:justify-center max-md:justify-start bg-topo-light bg-cover bg-center dark:bg-topo-dark bg-lightmode-background dark:bg-darkmode-background md:p-8 max-md:p-2 max-md:pt-20">
+      <div className="flex flex-col h-screen w-full snap-start items-center md:justify-center max-md:justify-start md:p-8 max-md:p-2 max-md:pt-20">
         <section aria-labelledby="Overview" className="max-xl:h-[70vh] max-h-full flex flex-col justify-center items-center  max-xl:w-full xl:w-1/2 xl:h-4/6 font-londrina gap-1 md:gap-2">
           {/* Section Header */}
-          <div className="w-full h-fit flex items-baseline text-lightmode-primary dark:text-darkmode-primary font-extrabold">
+          <div className="w-full h-fit flex items-baseline text-lightmode-primary transition duration-500 dark:text-darkmode-primary font-extrabold">
             <h2 id="Overview" className="text-4xl mx-2">2024 Overview</h2>
-            <div className="h-[2px] flex-auto bg-lightmode-primary dark:bg-darkmode-primary rounded-sm"></div>
+            <div className="h-[2px] flex-auto bg-lightmode-primary transition duration-500 dark:bg-darkmode-primary rounded-sm"></div>
           </div>
           <div className="w-full h-full px-4 md:px-6 lg:px-8 overflow-hidden grid xl:grid-cols-2 max-xl:grid-cold-1  xl:grid-rows-2 max-xl:grid-rows-4 p-2 xl:gap-4 max-xl:gap-2">
-          <div className="grid md:grid-cols-5 max-md:grid-rows-4 p-3 w-full xl:col-span-full max-xl:row-span-2 h-full backdrop-blur border-2 border-lightmode-border dark:border-darkmode-border rounded-tl-3xl rounded-br-3xl rounded-tr-lg rounded-bl-lg">
+          <div className="grid md:grid-cols-5 max-md:grid-rows-4 p-3 w-full xl:col-span-full max-xl:row-span-2 h-full backdrop-blur border-2 border-lightmode-border transition duration-500 dark:border-darkmode-border rounded-tl-3xl rounded-br-3xl rounded-tr-lg rounded-bl-lg">
               <div className="flex flex-col justify-center items-center p-2 max-md:hidden">
                 <a className="w-3/4" href={`https://more.tf/profile/${profileData?.general[0].id64}`} target="_blank">
                   <img
@@ -231,73 +231,73 @@ const Recap: React.FC = () => {
                   />
                 </a>
               </div>
-              <div className="flex md:flex-col justify-center items-center font-black select-none md:border-r-2 max-md:border-b-2 border-lightmode-border dark:border-darkmode-border max-md:gap-2">
-                <div className="xl:text-[4.2vw] max-xl:text-[9.4vw] max-md:text-[8vw] xl:-mb-[2.3vw] max-xl:-my-[4.8vw] max-md:w-full max-md:text-right text-lightmode-tertiary dark:text-darkmode-tertiary">{profileData?.general[0].matches_played ? formatNumber(profileData.general[0].matches_played) : "0"}</div>
-                <div className="xl:text-[2.6vw] max-xl:text-[5.4vw] max-md:text-[8vw] max-xl:-mb-[5vw] max-md:mb-0 max-md:w-full max-md:text-left text-lightmode-primary dark:text-darkmode-primary">GAMES</div>
+              <div className="flex md:flex-col justify-center items-center font-black select-none md:border-r-2 max-md:border-b-2 border-lightmode-border transition duration-500 dark:border-darkmode-border max-md:gap-2">
+                <div className="xl:text-[4.2vw] max-xl:text-[9.4vw] max-md:text-[8vw] xl:-mb-[2.3vw] max-xl:-my-[4.8vw] max-md:w-full max-md:text-right text-lightmode-tertiary transition duration-500 dark:text-darkmode-tertiary">{profileData?.general[0].matches_played ? formatNumber(profileData.general[0].matches_played) : "0"}</div>
+                <div className="xl:text-[2.6vw] max-xl:text-[5.4vw] max-md:text-[8vw] max-xl:-mb-[5vw] max-md:mb-0 max-md:w-full max-md:text-left text-lightmode-primary transition duration-500 dark:text-darkmode-primary">GAMES</div>
               </div>
-              <div className="flex md:flex-col justify-center items-center font-black select-none md:border-r-2 max-md:border-b-2 border-lightmode-border dark:border-darkmode-border max-md:gap-2">
-                <div className="xl:text-[4.2vw] max-xl:text-[9.4vw] max-md:text-[8vw] xl:-mb-[2.3vw] max-xl:-my-[4.8vw] max-md:w-full max-md:text-right text-lightmode-tertiary dark:text-darkmode-tertiary">{profileData?.general[0].time_played ? formatNumber((profileData.general[0].time_played/60/60).toFixed(0)) : "0"}</div>
-                <div className="xl:text-[2.6vw] max-xl:text-[5.4vw] max-md:text-[8vw] max-xl:-mb-[5vw] max-md:mb-0 max-md:w-full max-md:text-left text-lightmode-primary dark:text-darkmode-primary" aria-hidden="true">HOURS</div>
+              <div className="flex md:flex-col justify-center items-center font-black select-none md:border-r-2 max-md:border-b-2 border-lightmode-border transition duration-500 dark:border-darkmode-border max-md:gap-2">
+                <div className="xl:text-[4.2vw] max-xl:text-[9.4vw] max-md:text-[8vw] xl:-mb-[2.3vw] max-xl:-my-[4.8vw] max-md:w-full max-md:text-right text-lightmode-tertiary transition duration-500 dark:text-darkmode-tertiary">{profileData?.general[0].time_played ? formatNumber((profileData.general[0].time_played/60/60).toFixed(0)) : "0"}</div>
+                <div className="xl:text-[2.6vw] max-xl:text-[5.4vw] max-md:text-[8vw] max-xl:-mb-[5vw] max-md:mb-0 max-md:w-full max-md:text-left text-lightmode-primary transition duration-500 dark:text-darkmode-primary" aria-hidden="true">HOURS</div>
               </div>
-              <div className="flex md:flex-col justify-center items-center font-black select-none md:border-r-2 max-md:border-b-2 border-lightmode-border dark:border-darkmode-border max-md:gap-2">
-                <div className="xl:text-[4.2vw] max-xl:text-[9.4vw] max-md:text-[8vw] xl:-mb-[2.3vw] max-xl:-my-[4.8vw] max-md:w-full max-md:text-right text-lightmode-tertiary dark:text-darkmode-tertiary">{((profileData.general[0].matches_won/profileData.general[0].matches_played)*100).toFixed(0)}%</div>
-                <div className="xl:text-[2.6vw] max-xl:text-[5.4vw] max-md:text-[8vw] max-xl:-mb-[5vw] max-md:mb-0 max-md:w-full max-md:text-left text-lightmode-primary dark:text-darkmode-primary" aria-hidden="true">WIN%</div>
+              <div className="flex md:flex-col justify-center items-center font-black select-none md:border-r-2 max-md:border-b-2 border-lightmode-border transition duration-500 dark:border-darkmode-border max-md:gap-2">
+                <div className="xl:text-[4.2vw] max-xl:text-[9.4vw] max-md:text-[8vw] xl:-mb-[2.3vw] max-xl:-my-[4.8vw] max-md:w-full max-md:text-right text-lightmode-tertiary transition duration-500 dark:text-darkmode-tertiary">{((profileData.general[0].matches_won/profileData.general[0].matches_played)*100).toFixed(0)}%</div>
+                <div className="xl:text-[2.6vw] max-xl:text-[5.4vw] max-md:text-[8vw] max-xl:-mb-[5vw] max-md:mb-0 max-md:w-full max-md:text-left text-lightmode-primary transition duration-500 dark:text-darkmode-primary" aria-hidden="true">WIN%</div>
               </div>
-              <div className="flex md:flex-col justify-center items-center font-black select-none border-lightmode-border dark:border-darkmode-border max-md:gap-2">
-                <div className="xl:text-[4.2vw] max-xl:text-[9.4vw] max-md:text-[8vw] xl:-mb-[2.3vw] max-xl:-my-[4.8vw] max-md:w-full max-md:text-right text-lightmode-tertiary dark:text-darkmode-tertiary">{profileData?.general[0].kills ? ((profileData.general[0].kills + profileData.general[0].assists) / profileData.general[0].deaths).toFixed(1) : "0"}</div>
-                <div className="xl:text-[2.6vw] max-xl:text-[5.4vw] max-md:text-[8vw] max-xl:-mb-[5vw] max-md:mb-0 max-md:w-full max-md:text-left text-lightmode-primary dark:text-darkmode-primary" aria-hidden="true">KDA</div>
+              <div className="flex md:flex-col justify-center items-center font-black select-none border-lightmode-border transition duration-500 dark:border-darkmode-border max-md:gap-2">
+                <div className="xl:text-[4.2vw] max-xl:text-[9.4vw] max-md:text-[8vw] xl:-mb-[2.3vw] max-xl:-my-[4.8vw] max-md:w-full max-md:text-right text-lightmode-tertiary transition duration-500 dark:text-darkmode-tertiary">{profileData?.general[0].kills ? ((profileData.general[0].kills + profileData.general[0].assists) / profileData.general[0].deaths).toFixed(1) : "0"}</div>
+                <div className="xl:text-[2.6vw] max-xl:text-[5.4vw] max-md:text-[8vw] max-xl:-mb-[5vw] max-md:mb-0 max-md:w-full max-md:text-left text-lightmode-primary transition duration-500 dark:text-darkmode-primary" aria-hidden="true">KDA</div>
               </div>
             </div>
-            <div className="w-full p-2 h-full backdrop-blur border-2 border-lightmode-border dark:border-darkmode-border rounded-tl-3xl rounded-br-3xl rounded-tr-lg rounded-bl-lg">
+            <div className="w-full p-2 h-full backdrop-blur border-2 border-lightmode-border transition duration-500 dark:border-darkmode-border rounded-tl-3xl rounded-br-3xl rounded-tr-lg rounded-bl-lg">
               <div className="grid xl:grid-rows-2 max-xl:grid-rows-1 max-xl:grid-cols-5 h-full w-full items-center">
                 <div className="grid md:grid-cols-2 max-md:grid-rows-2 max-md:h-5/6  md:gap-2 max-xl:col-span-2">
                   <div className="flex flex-col justify-center items-center w-full h-full max-xl:order-2">
                     {/* TOP MAP Title */}
-                    <div className="text-lightmode-secondary dark:text-darkmode-secondary font-bold lg:-mb-2 lg:text-3xl max-lg:text-2xl max-md:hidden">TOP MAP</div>
-                    <div className="text-lightmode-primary dark:text-darkmode-primary font-bold text-center leading-none text-3xl pr-2 md:hidden">{profileData?.topFiveMaps[0]?.map_name?.toUpperCase() || "MAP NAME"}</div>
+                    <div className="text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary font-bold lg:-mb-2 lg:text-3xl max-lg:text-2xl max-md:hidden">TOP MAP</div>
+                    <div className="text-lightmode-primary transition duration-500 dark:text-darkmode-primary font-bold text-center leading-none text-3xl pr-2 md:hidden">{profileData?.topFiveMaps[0]?.map_name?.toUpperCase() || "MAP NAME"}</div>
                     {/* Dynamic Map Name */}
                     <div
-                    className="text-lightmode-primary dark:text-darkmode-primary font-bold text-center leading-none md:inline max-md:hidden"
+                    className="text-lightmode-primary transition duration-500 dark:text-darkmode-primary font-bold text-center leading-none md:inline max-md:hidden"
                     style={{
                       fontSize: `min(calc(20vw / ${profileData?.topFiveMaps[0].map_name.length || 1}), 4rem)`, // Adjust size dynamically based on text length
                       width: "100%", // Stretches to fill available width
                       textAlign: "center", // Ensures text remains centered
                     }}>{profileData?.topFiveMaps[0]?.map_name?.toUpperCase() || "MAP NAME"}</div>
                   </div>
-                  <div className="relative p-2 w-full h-full flex-auto max-md:pr-2 aspect-video after:absolute after:inset-2 after:bg-lightmode-background after:mix-blend-multiply after:dark:bg-darkmode-tertiary after:dark:mix-blend-multiply after:rounded-xl">
-                    <div className="relative w-full h-full flex-auto aspect-video after:absolute after:inset-0 after:bg-lightmode-tertiary after:mix-blend-screen after:dark:bg-darkmode-background after:dark:mix-blend-screen after:rounded-xl">
+                  <div className="relative p-2 w-full h-full flex-auto max-md:pr-2 aspect-video after:absolute after:inset-2 after:bg-lightmode-background after:mix-blend-multiply after:transition after:duration-500 after:dark:bg-darkmode-tertiary after:dark:mix-blend-multiply after:rounded-xl">
+                    <div className="relative w-full h-full flex-auto aspect-video after:absolute after:inset-0 after:bg-lightmode-tertiary after:mix-blend-screen after:transition after:duration-500 after:dark:bg-darkmode-background after:dark:mix-blend-screen after:rounded-xl">
                       <img loading="eager" src={`/maps/${profileData?.topFiveMaps[0].map_name}.png`} alt={`Image of the map ${profileData?.topFiveMaps[0].map_name}`} className="grayscale rounded-xl w-full h-full flex-auto object-cover"/>
                     </div>
                   </div>
                 </div>
                 <div className="grid grid-cols-3 max-xl:col-span-3">
                   <div className="flex flex-col justify-center items-center">
-                    <div className=" text-lightmode-secondary dark:text-darkmode-secondary md:text-xl max-md:text-lg max-sm:text-base max-xs:text-sm">Playtime</div>
-                    <div className=" text-lightmode-primary dark:text-darkmode-primary text-4xl max-md:text-[8vw]">{(profileData?.topFiveMaps[0].time_played / 60 / 60).toFixed(0)}<span className="text-sm text-lightmode-tertiary dark:text-darkmode-tertiary">hrs</span></div>
+                    <div className=" text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary md:text-xl max-md:text-lg max-sm:text-base max-xs:text-sm">Playtime</div>
+                    <div className=" text-lightmode-primary transition duration-500 dark:text-darkmode-primary text-4xl max-md:text-[8vw]">{(profileData?.topFiveMaps[0].time_played / 60 / 60).toFixed(0)}<span className="text-sm text-lightmode-tertiary transition duration-500 dark:text-darkmode-tertiary">hrs</span></div>
                   </div>
                   <div className="flex flex-col justify-center items-center">
-                    <div className=" text-lightmode-secondary dark:text-darkmode-secondary md:text-xl max-md:text-lg max-sm:text-base max-xs:text-sm">W/L Ratio</div>
-                    <div className=" text-lightmode-primary dark:text-darkmode-primary text-4xl max-md:text-[8vw]">{(profileData?.topFiveMaps[0].wins / (profileData?.topFiveMaps[0].wins + profileData?.topFiveMaps[0].losses) * 100).toFixed(0)}%</div>
+                    <div className=" text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary md:text-xl max-md:text-lg max-sm:text-base max-xs:text-sm">W/L Ratio</div>
+                    <div className=" text-lightmode-primary transition duration-500 dark:text-darkmode-primary text-4xl max-md:text-[8vw]">{(profileData?.topFiveMaps[0].wins / (profileData?.topFiveMaps[0].wins + profileData?.topFiveMaps[0].losses) * 100).toFixed(0)}%</div>
                   </div>
                   <div className="flex flex-col justify-center items-center">
-                    <div className=" text-lightmode-secondary dark:text-darkmode-secondary md:text-xl max-md:text-lg max-sm:text-base max-xs:text-sm">Matches</div>
-                    <div className=" text-lightmode-primary dark:text-darkmode-primary text-4xl max-md:text-[8vw]">{profileData?.topFiveMaps[0].matches_played}</div>
+                    <div className=" text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary md:text-xl max-md:text-lg max-sm:text-base max-xs:text-sm">Matches</div>
+                    <div className=" text-lightmode-primary transition duration-500 dark:text-darkmode-primary text-4xl max-md:text-[8vw]">{profileData?.topFiveMaps[0].matches_played}</div>
                   </div>
                 </div>
               </div>
             </div>
-            <div className="w-full p-2 h-full backdrop-blur border-2 border-lightmode-border dark:border-darkmode-border rounded-tl-3xl rounded-br-3xl rounded-tr-lg rounded-bl-lg">
+            <div className="w-full p-2 h-full backdrop-blur border-2 border-lightmode-border transition duration-500 dark:border-darkmode-border rounded-tl-3xl rounded-br-3xl rounded-tr-lg rounded-bl-lg">
               <div className="grid xl:grid-rows-2 max-xl:grid-rows-1 max-xl:grid-cols-5 h-full w-full items-center">
                 <div className="grid md:grid-cols-2 max-md:grid-rows-2 max-md:h-5/6  md:gap-2 max-xl:col-span-2">
                 <div className="flex flex-col justify-center items-center w-full h-full max-xl:order-2">
                   {/* TOP CLASS Title */}
-                  <div className=" text-lightmode-secondary dark:text-darkmode-secondary font-bold lg:-mb-2 lg:text-3xl max-lg:text-2xl max-md:hidden">
+                  <div className=" text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary font-bold lg:-mb-2 lg:text-3xl max-lg:text-2xl max-md:hidden">
                     TOP CLASS
                   </div>
-                  <div className=" text-lightmode-primary dark:text-darkmode-primary font-bold text-center leading-none text-3xl pr-2 md:hidden">{profileData?.topFiveClasses[0]?.class_name?.toUpperCase() || "MAP NAME"}</div>
+                  <div className=" text-lightmode-primary transition duration-500 dark:text-darkmode-primary font-bold text-center leading-none text-3xl pr-2 md:hidden">{profileData?.topFiveClasses[0]?.class_name?.toUpperCase() || "MAP NAME"}</div>
                   {/* Dynamic Class Name */}
                     <div
-                    className=" text-lightmode-primary dark:text-darkmode-primary font-bold text-center leading-none max-md:hidden "
+                    className=" text-lightmode-primary transition duration-500 dark:text-darkmode-primary font-bold text-center leading-none max-md:hidden "
                     style={{
                       fontSize: `min(calc(20vw / ${profileData?.topFiveClasses[0].class_name.length || 1}), 4rem)`, // Adjust size dynamically based on text length
                       width: "100%", // Stretches to fill available width
@@ -307,49 +307,49 @@ const Recap: React.FC = () => {
                       {profileData?.topFiveClasses[0].class_name?.toUpperCase() || "MAP NAME"}
                     </div>
                   </div>
-                  <div className="relative p-2 w-full h-full flex-auto max-md:pr-2 aspect-video after:absolute after:inset-2 after:bg-lightmode-background after:mix-blend-multiply after:dark:bg-darkmode-tertiary after:dark:mix-blend-multiply after:rounded-xl">
-                    <div className="relative w-full h-full flex-auto aspect-video after:absolute after:inset-0 after:bg-lightmode-tertiary after:mix-blend-screen after:dark:bg-darkmode-background after:dark:mix-blend-screen after:rounded-xl">
+                  <div className="relative p-2 w-full h-full flex-auto max-md:pr-2 aspect-video after:absolute after:inset-2 after:bg-lightmode-background after:mix-blend-multiply after:transition after:duration-500 after:dark:bg-darkmode-tertiary after:dark:mix-blend-multiply after:rounded-xl">
+                    <div className="relative w-full h-full flex-auto aspect-video after:absolute after:inset-0 after:bg-lightmode-tertiary after:mix-blend-screen after:transition after:duration-500 after:dark:bg-darkmode-background after:dark:mix-blend-screen after:rounded-xl">
                       <img loading="eager" src={`/classes/${profileData?.topFiveClasses[0].class_name}.png`} alt={`Picture of ${profileData?.topFiveClasses[0].class_name} staring at the camera`} className="rounded-xl w-full h-full flex-auto object-cover" />
                     </div>
                   </div>
                 </div>
                 <div className="grid grid-cols-3 max-xl:col-span-3">
                   <div className="flex flex-col justify-center items-center">
-                    <div className=" text-lightmode-secondary dark:text-darkmode-secondary md:text-xl max-md:text-lg max-sm:text-base max-xs:text-sm">Playtime</div>
-                    <div className=" text-lightmode-primary dark:text-darkmode-primary text-4xl max-md:text-[8vw]">{(profileData?.topFiveClasses[0].time_played / 60 / 60).toFixed(0)}<span className="text-sm  text-lightmode-tertiary dark:text-darkmode-tertiary">hrs</span></div>
+                    <div className=" text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary md:text-xl max-md:text-lg max-sm:text-base max-xs:text-sm">Playtime</div>
+                    <div className=" text-lightmode-primary transition duration-500 dark:text-darkmode-primary text-4xl max-md:text-[8vw]">{(profileData?.topFiveClasses[0].time_played / 60 / 60).toFixed(0)}<span className="text-sm  text-lightmode-tertiary transition duration-500 dark:text-darkmode-tertiary">hrs</span></div>
                   </div>
                   <div className="flex flex-col justify-center items-center">
-                    <div className=" text-lightmode-secondary dark:text-darkmode-secondary md:text-xl max-md:text-lg max-sm:text-base max-xs:text-sm">W/L Ratio</div>
-                    <div className=" text-lightmode-primary dark:text-darkmode-primary text-4xl max-md:text-[8vw]">{(profileData?.topFiveClasses[0].wins / profileData?.topFiveClasses[0].matches_played * 100).toFixed(0)}%</div>
+                    <div className=" text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary md:text-xl max-md:text-lg max-sm:text-base max-xs:text-sm">W/L Ratio</div>
+                    <div className=" text-lightmode-primary transition duration-500 dark:text-darkmode-primary text-4xl max-md:text-[8vw]">{(profileData?.topFiveClasses[0].wins / profileData?.topFiveClasses[0].matches_played * 100).toFixed(0)}%</div>
                   </div>
                   <div className="flex flex-col justify-center items-center">
-                    <div className=" text-lightmode-secondary dark:text-darkmode-secondary md:text-xl max-md:text-lg max-sm:text-base max-xs:text-sm">Matches</div>
-                    <div className=" text-lightmode-primary dark:text-darkmode-primary text-4xl max-md:text-[8vw]">{profileData?.topFiveClasses[0].matches_played}</div>
+                    <div className=" text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary md:text-xl max-md:text-lg max-sm:text-base max-xs:text-sm">Matches</div>
+                    <div className=" text-lightmode-primary transition duration-500 dark:text-darkmode-primary text-4xl max-md:text-[8vw]">{profileData?.topFiveClasses[0].matches_played}</div>
                   </div>
                 </div>
               </div>
             </div>            
           </div>
-          <div className="h-[2px] w-full bg-lightmode-primary dark:bg-darkmode-primary rounded-sm"></div>
+          <div className="h-[2px] w-full bg-lightmode-primary transition duration-500 dark:bg-darkmode-primary rounded-sm"></div>
         </section>
       </div>
 
       {/* Most Played Classes New Style */}
-      <div className="flex flex-col h-screen w-full snap-start items-center md:justify-center max-md:justify-start bg-topo-light bg-cover bg-center dark:bg-topo-dark bg-lightmode-background dark:bg-darkmode-background md:p-8 max-md:p-2 max-md:pt-20">
+      <div className="flex flex-col h-screen w-full snap-start items-center md:justify-center max-md:justify-start md:p-8 max-md:p-2 max-md:pt-20">
         <section aria-labelledby="TopClasses" className="max-xl:h-[70vh] max-h-full flex flex-col justify-center items-center max-xl:w-full xl:w-1/2 xl:h-4/6 font-londrina">
           {/* Section Header */}
-          <div className="w-full h-fit flex items-baseline text-lightmode-primary dark:text-darkmode-primary font-extrabold">
+          <div className="w-full h-fit flex items-baseline text-lightmode-primary transition duration-500 dark:text-darkmode-primary font-extrabold">
             <h2 id="TopClasses" className="text-4xl mx-2">Most Played Classes</h2>
-            <div className="h-[2px] flex-grow bg-lightmode-primary dark:bg-darkmode-primary rounded-sm"></div>
+            <div className="h-[2px] flex-grow bg-lightmode-primary transition duration-500 dark:bg-darkmode-primary rounded-sm"></div>
           </div>
 
           {/* Cards */}
           <div className={`w-full h-full overflow-hidden flex flex-col p-2 xl:gap-3 max-xl:gap-2`}>
             {Array.from({ length: profileData?.topFiveClasses.length || 0 }).map((_,index:any) => (
-              <div key={index} className={`relative md:p-3 max-md:px-2 flex w-full h-4 flex-auto backdrop-blur border-2 border-lightmode-border dark:border-darkmode-border rounded-tl-3xl rounded-br-3xl rounded-tr-lg rounded-bl-lg`}>
-                <div className="absolute bottom-0 left-2 text-lightmode-primary dark:text-darkmode-primary opacity-50">{index+1}.</div>
-                <div className="relative mr-2 max-md:my-2 after:absolute after:inset-0 after:bg-lightmode-background after:mix-blend-darken after:dark:bg-darkmode-tertiary after:dark:mix-blend-multiply after:rounded-tl-xl after:rounded-br-xl">
-                  <div className="relative h-full after:absolute after:inset-0 after:bg-lightmode-tertiary after:mix-blend-screen after:dark:bg-darkmode-background after:dark:mix-blend-screen after:rounded-tl-xl after:rounded-br-xl">
+              <div key={index} className={`relative md:p-3 max-md:px-2 flex w-full h-4 flex-auto backdrop-blur border-2 border-lightmode-border transition duration-500 dark:border-darkmode-border rounded-tl-3xl rounded-br-3xl rounded-tr-lg rounded-bl-lg`}>
+                <div className="absolute bottom-0 left-2 text-lightmode-primary transition duration-500 dark:text-darkmode-primary opacity-50">{index+1}.</div>
+                <div className="relative mr-2 max-md:my-2 after:absolute after:inset-0 after:bg-lightmode-background after:mix-blend-multiply after:transition after:duration-500 after:dark:bg-darkmode-tertiary after:dark:mix-blend-multiply after:rounded-tl-xl after:rounded-br-xl">
+                  <div className="relative h-full after:absolute after:inset-0 after:bg-lightmode-tertiary after:mix-blend-screen after:transition after:duration-500 after:dark:bg-darkmode-background after:dark:mix-blend-screen after:rounded-tl-xl after:rounded-br-xl">
                     <img
                       loading="lazy"
                       src={`/portraits/${profileData?.topFiveClasses[index].class_name}.png`}
@@ -363,14 +363,14 @@ const Recap: React.FC = () => {
                   {/* Class Title */}
                   <div className="w-full h-full">
                     <div className="h-full text-left flex flex-col justify-center items-start">
-                      <h3 className="md:text-3xl sm:text-2xl max-sm:text-lg font-semibold text-lightmode-primary dark:text-darkmode-primary -my-1">
+                      <h3 className="md:text-3xl sm:text-2xl max-sm:text-lg font-semibold text-lightmode-primary transition duration-500 dark:text-darkmode-primary -my-1">
                         {classes[profileData?.topFiveClasses[index].class_name].toUpperCase()}
                       </h3>
                       <div className="flex max-xl:flex-col xl:flex-row xl:gap-2">
-                        <p className="text-sm  text-lightmode-secondary dark:text-darkmode-secondary ">
+                        <p className="text-sm  text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary ">
                           {(Number(profileData?.topFiveClasses[index].time_played) /60 /60).toFixed(1)}{" "}hrs
                         </p>
-                        <p className="text-sm max-md:hidden  text-lightmode-secondary dark:text-darkmode-secondary">
+                        <p className="text-sm max-md:hidden  text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary">
                           {profileData?.topFiveClasses[index].matches_played} matches
                         </p>
                       </div>
@@ -381,9 +381,9 @@ const Recap: React.FC = () => {
                     <div className="w-full h-full flex justify-center items-center flex-wrap gap-[0.8vw]">
                       {/* Kills */}
                       <div className="flex justify-center items-center md:flex-col">
-                        <div className="mr-2 md:hidden  text-lightmode-secondary dark:text-darkmode-secondary xl:text-[1.3vw] max-md:text-sm max-xl:text-[2.8vw]">KDA:</div>
-                        <div className="max-md:hidden  text-lightmode-secondary dark:text-darkmode-secondary xl:text-[1vw] max-xl:text-[2vw]">KILLS</div>
-                        <div className="flex items-center text-lightmode-primary dark:text-darkmode-primary xl:text-[1.3vw] max-xl:text-[2.8vw] max-md:text-sm md:-mt-[0.5vw]">
+                        <div className="mr-2 md:hidden  text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary xl:text-[1.3vw] max-md:text-sm max-xl:text-[2.8vw]">KDA:</div>
+                        <div className="max-md:hidden  text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary xl:text-[1vw] max-xl:text-[2vw]">KILLS</div>
+                        <div className="flex items-center text-lightmode-primary transition duration-500 dark:text-darkmode-primary xl:text-[1.3vw] max-xl:text-[2.8vw] max-md:text-sm md:-mt-[0.5vw]">
                           <span className="font-bold">{formatNumber(profileData?.topFiveClasses[index].kills)}</span>
                           <span className="md:hidden mx-1">/</span>
                         </div>
@@ -391,8 +391,8 @@ const Recap: React.FC = () => {
 
                       {/* Deaths */}
                       <div className="flex justify-center items-center md:flex-col">
-                        <div className="max-md:hidden  text-lightmode-secondary dark:text-darkmode-secondary xl:text-[1vw] max-xl:text-[2vw]">DEATHS</div>
-                        <div className="flex items-center text-lightmode-primary dark:text-darkmode-primary xl:text-[1.3vw] max-xl:text-[2.8vw] max-md:text-sm md:-mt-[0.5vw]">
+                        <div className="max-md:hidden  text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary xl:text-[1vw] max-xl:text-[2vw]">DEATHS</div>
+                        <div className="flex items-center text-lightmode-primary transition duration-500 dark:text-darkmode-primary xl:text-[1.3vw] max-xl:text-[2.8vw] max-md:text-sm md:-mt-[0.5vw]">
                           <span className="font-bold">{formatNumber(profileData?.topFiveClasses[index].deaths)}</span>
                           <span className="md:hidden mx-1">/</span>
                         </div>
@@ -400,8 +400,8 @@ const Recap: React.FC = () => {
 
                       {/* Assists */}
                       <div className="flex justify-center items-center md:flex-col">
-                        <div className="max-md:hidden  text-lightmode-secondary dark:text-darkmode-secondary xl:text-[1vw] max-xl:text-[2vw]">ASSISTS</div>
-                        <div className="flex items-center text-lightmode-primary dark:text-darkmode-primary xl:text-[1.3vw] max-xl:text-[2.8vw] max-md:text-sm md:-mt-[0.5vw]">
+                        <div className="max-md:hidden  text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary xl:text-[1vw] max-xl:text-[2vw]">ASSISTS</div>
+                        <div className="flex items-center text-lightmode-primary transition duration-500 dark:text-darkmode-primary xl:text-[1.3vw] max-xl:text-[2.8vw] max-md:text-sm md:-mt-[0.5vw]">
                           <span className="font-bold">{formatNumber(profileData?.topFiveClasses[index].assists)}</span>
                         </div>
                       </div>
@@ -412,17 +412,17 @@ const Recap: React.FC = () => {
                       <div className="flex justify-center items-center md:gap-4 xl:gap-2">
                         {/* Wins */}
                         <div className="flex justify-center items-center md:flex-row-reverse md:gap-x-2">
-                          <div className="mr-2 md:hidden  text-lightmode-secondary dark:text-darkmode-secondary xl:text-[1.3vw] max-md:text-sm max-xl:text-[2.8vw]">W/L:</div>
-                          <div className="max-md:hidden  text-lightmode-secondary dark:text-darkmode-secondary xl:text-[1vw] max-xl:text-[2vw]">WINS</div>
-                          <div className="flex items-center text-lightmode-primary dark:text-darkmode-primary xl:text-[1.3vw] max-xl:text-[2.8vw] max-md:text-sm">
+                          <div className="mr-2 md:hidden  text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary xl:text-[1.3vw] max-md:text-sm max-xl:text-[2.8vw]">W/L:</div>
+                          <div className="max-md:hidden  text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary xl:text-[1vw] max-xl:text-[2vw]">WINS</div>
+                          <div className="flex items-center text-lightmode-primary transition duration-500 dark:text-darkmode-primary xl:text-[1.3vw] max-xl:text-[2.8vw] max-md:text-sm">
                             <span className="font-bold">{formatNumber(profileData?.topFiveClasses[index].wins)}</span>
                             <span className="md:hidden mx-1">/</span>
                           </div>
                         </div>
                         {/* Losses */}
                         <div className="flex justify-center items-center md:flex-row-reverse md:gap-x-2">
-                          <div className="max-md:hidden  text-lightmode-secondary dark:text-darkmode-secondary xl:text-[1vw] max-xl:text-[2vw]">LOSSES</div>
-                          <div className="flex items-center text-lightmode-primary dark:text-darkmode-primary xl:text-[1.3vw] max-xl:text-[2.8vw] max-md:text-sm">
+                          <div className="max-md:hidden  text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary xl:text-[1vw] max-xl:text-[2vw]">LOSSES</div>
+                          <div className="flex items-center text-lightmode-primary transition duration-500 dark:text-darkmode-primary xl:text-[1.3vw] max-xl:text-[2.8vw] max-md:text-sm">
                             <span className="font-bold">{formatNumber(profileData?.topFiveClasses[index].losses)}</span>
                           </div>
                         </div>
@@ -449,9 +449,9 @@ const Recap: React.FC = () => {
                     <div className="w-full flex justify-center items-center">
                       {/* Damage / Heals */}
                       <div className="flex justify-center items-center md:flex-col ">
-                          <div className="mr-2 md:hidden  text-lightmode-secondary dark:text-darkmode-secondary xl:text-[1.3vw] max-md:text-sm max-xl:text-[2.8vw]">{profileData?.topFiveClasses[index].class_name ==="medic" ? "HEALS" : "DAMAGE"}:</div>
-                          <div className="max-md:hidden  text-lightmode-secondary dark:text-darkmode-secondary xl:text-[1vw] max-xl:text-[2vw]">{profileData?.topFiveClasses[index].class_name ==="medic" ? "HEALS" : "DAMAGE"}</div>
-                          <div className="flex items-center text-lightmode-primary dark:text-darkmode-primary xl:text-[1.3vw] max-xl:text-[2.8vw] max-md:text-sm md:-mt-[0.5vw]">
+                          <div className="mr-2 md:hidden  text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary xl:text-[1.3vw] max-md:text-sm max-xl:text-[2.8vw]">{profileData?.topFiveClasses[index].class_name ==="medic" ? "HEALS" : "DAMAGE"}:</div>
+                          <div className="max-md:hidden  text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary xl:text-[1vw] max-xl:text-[2vw]">{profileData?.topFiveClasses[index].class_name ==="medic" ? "HEALS" : "DAMAGE"}</div>
+                          <div className="flex items-center text-lightmode-primary transition duration-500 dark:text-darkmode-primary xl:text-[1.3vw] max-xl:text-[2.8vw] max-md:text-sm md:-mt-[0.5vw]">
                             <span className="font-bold">{profileData?.topFiveClasses[index].class_name ==="medic"? Number(profileData?.topFiveClasses[index].healing).toLocaleString(): Number(profileData?.topFiveClasses[index].damage).toLocaleString()}</span>
                           </div>
                         </div>
@@ -461,26 +461,26 @@ const Recap: React.FC = () => {
               </div>
             ))}
           </div>
-          <div className="h-[2px] w-full bg-lightmode-primary dark:bg-darkmode-primary rounded-sm"></div>
+          <div className="h-[2px] w-full bg-lightmode-primary transition duration-500 dark:bg-darkmode-primary rounded-sm"></div>
         </section>
       </div>
 
       {/* Most Played Maps New Style */}
-      <div className="flex flex-col h-screen  w-full snap-start items-center justify-center bg-topo-light bg-cover bg-center dark:bg-topo-dark bg-lightmode-background dark:bg-darkmode-background md:p-8 max-md:p-3">
+      <div className="flex flex-col h-screen  w-full snap-start items-center justify-center md:p-8 max-md:p-3">
         <section aria-labelledby="TopMaps" className="max-xl:h-[70vh] max-h-full flex flex-col justify-center items-center  max-xl:w-full xl:w-1/2 xl:h-4/6 font-londrina">
           {/* Section Header */}
-          <div className="w-full h-fit flex items-baseline text-lightmode-primary dark:text-darkmode-primary font-extrabold">
+          <div className="w-full h-fit flex items-baseline text-lightmode-primary transition duration-500 dark:text-darkmode-primary font-extrabold">
             <h2 id="TopMaps" className="text-4xl mx-2">Most Played Maps</h2>
-            <div className="h-[2px] flex-grow bg-lightmode-primary dark:bg-darkmode-primary rounded-sm"></div>
+            <div className="h-[2px] flex-grow bg-lightmode-primary transition duration-500 dark:bg-darkmode-primary rounded-sm"></div>
           </div>
 
           {/* Cards */}
           <div className={`w-full h-full overflow-hidden flex flex-col p-2 xl:gap-3 max-xl:gap-2`}>
             {Array.from({ length: profileData?.topFiveMaps.length || 0 }).map((_,index:any) => (
-              <div key={index} className="relative md:p-3 max-md:px-2 flex w-full h-4 flex-auto backdrop-blur border-2 border-lightmode-border dark:border-darkmode-border rounded-tl-3xl rounded-br-3xl rounded-tr-lg rounded-bl-lg">
-                <div className="absolute bottom-0 left-2 text-lightmode-primary dark:text-darkmode-primary opacity-50 ">{index+1}.</div>
-                <div className="relative mr-2 max-md:my-2 after:absolute after:inset-0 after:bg-lightmode-background after:mix-blend-multiply after:dark:bg-darkmode-tertiary after:dark:mix-blend-multiply after:rounded-tl-xl after:rounded-br-xl">
-                  <div className="relative h-full after:absolute after:inset-0 after:bg-lightmode-tertiary after:mix-blend-screen after:dark:bg-darkmode-background after:dark:mix-blend-screen after:rounded-tl-xl after:rounded-br-xl">
+              <div key={index} className="relative md:p-3 max-md:px-2 flex w-full h-4 flex-auto backdrop-blur border-2 border-lightmode-border transition duration-500 dark:border-darkmode-border rounded-tl-3xl rounded-br-3xl rounded-tr-lg rounded-bl-lg">
+                <div className="absolute bottom-0 left-2 text-lightmode-primary transition duration-500 dark:text-darkmode-primary opacity-50 ">{index+1}.</div>
+                <div className="relative mr-2 max-md:my-2 after:absolute after:inset-0 after:bg-lightmode-background after:mix-blend-multiply after:transition after:duration-500 after:dark:bg-darkmode-tertiary after:dark:mix-blend-multiply after:rounded-tl-xl after:rounded-br-xl">
+                  <div className="relative h-full after:absolute after:inset-0 after:bg-lightmode-tertiary after:mix-blend-screen after:transition after:duration-500 after:dark:bg-darkmode-background after:dark:mix-blend-screen after:rounded-tl-xl after:rounded-br-xl">
                     <img
                       loading="lazy"
                       src={`/maps/${profileData?.topFiveMaps[index].map_name}.png`}
@@ -493,14 +493,14 @@ const Recap: React.FC = () => {
                   {/* Map Title */}
                   <div className="w-full h-full">
                     <div className="h-full text-left flex flex-col justify-center items-start">
-                      <h3 className="md:text-3xl sm:text-2xl max-sm:text-lg font-semibold text-lightmode-primary dark:text-darkmode-primary -my-1">
+                      <h3 className="md:text-3xl sm:text-2xl max-sm:text-lg font-semibold text-lightmode-primary transition duration-500 dark:text-darkmode-primary -my-1">
                         {profileData?.topFiveMaps[index].map_name.toUpperCase()}
                       </h3>
                       <div className="flex max-xl:flex-col xl:flex-row xl:gap-2">
-                        <p className="text-sm  text-lightmode-secondary dark:text-darkmode-secondary ">
+                        <p className="text-sm  text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary ">
                           {(Number(profileData?.topFiveMaps[index].time_played) /60 /60).toFixed(1)}{" "}hrs
                         </p>
-                        <p className="text-sm max-md:hidden  text-lightmode-secondary dark:text-darkmode-secondary">
+                        <p className="text-sm max-md:hidden  text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary">
                           {profileData?.topFiveMaps[index].matches_played} matches
                         </p>
                       </div>
@@ -512,17 +512,17 @@ const Recap: React.FC = () => {
                       <div className="flex justify-center items-center md:gap-4">
                         {/* Wins */}
                         <div className="flex justify-center items-center md:flex-row-reverse md:gap-x-2">
-                          <div className="mr-2 md:hidden text-lightmode-secondary dark:text-darkmode-secondary xl:text-[1.3vw] max-md:text-sm max-xl:text-[2.8vw]">W/L:</div>
-                          <div className="max-md:hidden text-lightmode-secondary dark:text-darkmode-secondary xl:text-[1vw] max-xl:text-[2vw]">WINS</div>
-                          <div className="flex items-center text-lightmode-primary dark:text-darkmode-primary xl:text-[1.3vw] max-xl:text-[2.8vw] max-md:text-sm md:-mt-[0.5vw]">
+                          <div className="mr-2 md:hidden text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary xl:text-[1.3vw] max-md:text-sm max-xl:text-[2.8vw]">W/L:</div>
+                          <div className="max-md:hidden text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary xl:text-[1vw] max-xl:text-[2vw]">WINS</div>
+                          <div className="flex items-center text-lightmode-primary transition duration-500 dark:text-darkmode-primary xl:text-[1.3vw] max-xl:text-[2.8vw] max-md:text-sm md:-mt-[0.5vw]">
                             <span className="font-bold">{formatNumber(profileData?.topFiveMaps[index].wins)}</span>
                             <span className="md:hidden mx-1">/</span>
                           </div>
                         </div>
                         {/* Losses */}
                         <div className="flex justify-center items-center md:flex-row-reverse md:gap-x-2">
-                          <div className="max-md:hidden  text-lightmode-secondary dark:text-darkmode-secondary xl:text-[1vw] max-xl:text-[2vw]">LOSSES</div>
-                          <div className="flex items-center text-lightmode-primary dark:text-darkmode-primary xl:text-[1.3vw] max-xl:text-[2.8vw] max-md:text-sm md:-mt-[0.5vw]">
+                          <div className="max-md:hidden  text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary xl:text-[1vw] max-xl:text-[2vw]">LOSSES</div>
+                          <div className="flex items-center text-lightmode-primary transition duration-500 dark:text-darkmode-primary xl:text-[1.3vw] max-xl:text-[2.8vw] max-md:text-sm md:-mt-[0.5vw]">
                             <span className="font-bold">{formatNumber(profileData?.topFiveMaps[index].losses)}</span>
                           </div>
                         </div>
@@ -550,24 +550,24 @@ const Recap: React.FC = () => {
               </div>
             ))}
           </div>
-          <div className="h-[2px] w-full bg-lightmode-primary dark:bg-darkmode-primary rounded-sm"></div>
+          <div className="h-[2px] w-full bg-lightmode-primary transition duration-500 dark:bg-darkmode-primary rounded-sm"></div>
         </section>
       </div>
 
       {/* Most Played Teammate New Style */}
-      <div className="flex flex-col h-screen w-full snap-start items-center md:justify-center max-md:justify-start bg-topo-light bg-cover bg-center dark:bg-topo-dark bg-lightmode-background dark:bg-darkmode-background md:p-8 max-md:p-2 max-md:pt-20">
+      <div className="flex flex-col h-screen w-full snap-start items-center md:justify-center max-md:justify-start md:p-8 max-md:p-2 max-md:pt-20">
         <section aria-labelledby="TopTeammates" className="max-xl:h-[70vh] max-h-full flex flex-col justify-center items-center  max-xl:w-full xl:w-1/2 xl:h-4/6 font-londrina">
           {/* Section Header */}
-          <div className="w-full h-fit flex items-baseline text-lightmode-primary dark:text-darkmode-primary font-extrabold">
+          <div className="w-full h-fit flex items-baseline text-lightmode-primary transition duration-500 dark:text-darkmode-primary font-extrabold">
             <h2 id="TopTeammates" className="text-4xl mx-2">Most Played Teammates</h2>
-            <div className="h-[2px] flex-grow bg-lightmode-primary dark:bg-darkmode-primary rounded-sm"></div>
+            <div className="h-[2px] flex-grow bg-lightmode-primary transition duration-500 dark:bg-darkmode-primary rounded-sm"></div>
           </div>
 
           {/* Cards */}
           <div className="w-full h-full overflow-hidden flex flex-col p-2 xl:gap-3 max-xl:gap-2">
             {[0, 1, 2, 3, 4].map((section) => (
-              <div key={section} className="relative md:p-3 max-md:px-2 flex w-full h-4 flex-auto backdrop-blur border-2 border-lightmode-border dark:border-darkmode-border rounded-tl-3xl rounded-br-3xl rounded-tr-lg rounded-bl-lg">
-                <div className="absolute bottom-0 left-2 text-lightmode-primary dark:text-darkmode-primary opacity-50 ">{section+1}.</div>
+              <div key={section} className="relative md:p-3 max-md:px-2 flex w-full h-4 flex-auto backdrop-blur border-2 border-lightmode-border transition duration-500 dark:border-darkmode-border rounded-tl-3xl rounded-br-3xl rounded-tr-lg rounded-bl-lg">
+                <div className="absolute bottom-0 left-2 text-lightmode-primary transition duration-500 dark:text-darkmode-primary opacity-50 ">{section+1}.</div>
                 <div className="h-full w-fit flex items-center mr-2">
                   <img
                     loading="eager"
@@ -580,10 +580,10 @@ const Recap: React.FC = () => {
                   {/* Player Title */}
                   <div className="w-full h-full">
                     <div className="h-full text-left flex flex-col justify-center items-start w-full">
-                      <a className="md:text-3xl sm:text-2xl max-sm:text-lg font-semibold text-lightmode-primary dark:text-darkmode-primary -my-1 truncate overflow-hidden w-full hover:underline" href={`https://wrapped.tf/recap/${profileData?.teammates[section].teammate_id64}`} target="_blank">
+                      <a className="md:text-3xl sm:text-2xl max-sm:text-lg font-semibold text-lightmode-primary transition duration-500 dark:text-darkmode-primary -my-1 truncate overflow-hidden w-full hover:underline" href={`https://wrapped.tf/recap/${profileData?.teammates[section].teammate_id64}`} target="_blank">
                         {profileData?.steamInfo[profileData?.teammates[section].teammate_id64]?.name}
                       </a>
-                      <p className="text-sm max-md:hidden  text-lightmode-secondary dark:text-darkmode-secondary">
+                      <p className="text-sm max-md:hidden  text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary">
                         {profileData?.teammates[section].matches_played} matches
                       </p>
                     </div>
@@ -594,17 +594,17 @@ const Recap: React.FC = () => {
                       <div className="flex justify-center items-center md:gap-4">
                         {/* Wins */}
                         <div className="flex justify-center items-center md:flex-row-reverse md:gap-x-2">
-                          <div className="mr-2 md:hidden  text-lightmode-secondary dark:text-darkmode-secondary xl:text-[1.3vw] max-md:text-sm max-xl:text-[2.8vw]">W/L:</div>
-                          <div className="max-md:hidden  text-lightmode-secondary dark:text-darkmode-secondary xl:text-[1vw] max-xl:text-[2vw]">WINS</div>
-                          <div className="flex items-center text-lightmode-primary dark:text-darkmode-primary xl:text-[1.3vw] max-xl:text-[2.8vw] max-md:text-sm md:-mt-[0.5vw]">
+                          <div className="mr-2 md:hidden  text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary xl:text-[1.3vw] max-md:text-sm max-xl:text-[2.8vw]">W/L:</div>
+                          <div className="max-md:hidden  text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary xl:text-[1vw] max-xl:text-[2vw]">WINS</div>
+                          <div className="flex items-center text-lightmode-primary transition duration-500 dark:text-darkmode-primary xl:text-[1.3vw] max-xl:text-[2.8vw] max-md:text-sm md:-mt-[0.5vw]">
                             <span className="font-bold">{formatNumber(profileData?.teammates[section].wins)}</span>
                             <span className="md:hidden mx-1">/</span>
                           </div>
                         </div>
                         {/* Losses */}
                         <div className="flex justify-center items-center md:flex-row-reverse md:gap-x-2">
-                          <div className="max-md:hidden  text-lightmode-secondary dark:text-darkmode-secondary xl:text-[1vw] max-xl:text-[2vw]">LOSSES</div>
-                          <div className="flex items-center text-lightmode-primary dark:text-darkmode-primary xl:text-[1.3vw] max-xl:text-[2.8vw] max-md:text-sm md:-mt-[0.5vw]">
+                          <div className="max-md:hidden  text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary xl:text-[1vw] max-xl:text-[2vw]">LOSSES</div>
+                          <div className="flex items-center text-lightmode-primary transition duration-500 dark:text-darkmode-primary xl:text-[1.3vw] max-xl:text-[2.8vw] max-md:text-sm md:-mt-[0.5vw]">
                             <span className="font-bold">{formatNumber(profileData?.teammates[section].losses)}</span>
                           </div>
                         </div>
@@ -632,24 +632,24 @@ const Recap: React.FC = () => {
               </div>
             ))}
           </div>
-          <div className="h-[2px] w-full bg-lightmode-primary dark:bg-darkmode-primary rounded-sm"></div>
+          <div className="h-[2px] w-full bg-lightmode-primary transition duration-500 dark:bg-darkmode-primary rounded-sm"></div>
         </section>
       </div>
 
       {/* Most Played Oponents New Style */}
-      <div className="flex flex-col h-screen w-full snap-start items-center md:justify-center max-md:justify-start bg-topo-light bg-cover bg-center dark:bg-topo-dark bg-lightmode-background dark:bg-darkmode-background md:p-8 max-md:p-2 max-md:pt-20">
+      <div className="flex flex-col h-screen w-full snap-start items-center md:justify-center max-md:justify-start md:p-8 max-md:p-2 max-md:pt-20">
         <section aria-labelledby="TopOpponents" className="max-xl:h-[70vh] max-h-full flex flex-col justify-center items-center  max-xl:w-full xl:w-1/2 xl:h-4/6 font-londrina">
           {/* Section Header */}
-          <div className="w-full h-fit flex items-baseline text-lightmode-primary dark:text-darkmode-primary font-extrabold">
+          <div className="w-full h-fit flex items-baseline text-lightmode-primary transition duration-500 dark:text-darkmode-primary font-extrabold">
             <h2 id="TopOpponents" className="text-4xl mx-2">Most Played Opponents</h2>
-            <div className="h-[2px] flex-grow bg-lightmode-primary dark:bg-darkmode-primary rounded-sm"></div>
+            <div className="h-[2px] flex-grow bg-lightmode-primary transition duration-500 dark:bg-darkmode-primary rounded-sm"></div>
           </div>
 
           {/* Cards */}
           <div className="w-full h-full overflow-hidden flex flex-col p-2 xl:gap-3 max-xl:gap-2">
             {[0, 1, 2, 3, 4].map((section) => (
-              <div key={section} className="relative md:p-3 max-md:px-2 flex w-full h-4 flex-auto backdrop-blur border-2 border-lightmode-border dark:border-darkmode-border rounded-tl-3xl rounded-br-3xl rounded-tr-lg rounded-bl-lg">
-                <div className="absolute bottom-0 left-2 text-lightmode-primary dark:text-darkmode-primary opacity-50 ">{section+1}.</div>
+              <div key={section} className="relative md:p-3 max-md:px-2 flex w-full h-4 flex-auto backdrop-blur border-2 border-lightmode-border transition duration-500 dark:border-darkmode-border rounded-tl-3xl rounded-br-3xl rounded-tr-lg rounded-bl-lg">
+                <div className="absolute bottom-0 left-2 text-lightmode-primary transition duration-500 dark:text-darkmode-primary opacity-50 ">{section+1}.</div>
                 <div className="h-full w-fit flex items-center mr-2">
                   <img
                     loading="lazy"
@@ -662,10 +662,10 @@ const Recap: React.FC = () => {
                   {/* Opponent Title */}
                   <div className="w-full h-full">
                     <div className="h-full w-full text-left flex flex-col justify-center items-start">
-                      <a className="md:text-3xl sm:text-2xl max-sm:text-lg font-semibold text-lightmode-primary dark:text-darkmode-primary -my-1 truncate overflow-hidden w-full hover:underline" href={`https://wrapped.tf/recap/${profileData?.enemies[section].enemy_id64}`} target="_blank">
+                      <a className="md:text-3xl sm:text-2xl max-sm:text-lg font-semibold text-lightmode-primary transition duration-500 dark:text-darkmode-primary -my-1 truncate overflow-hidden w-full hover:underline" href={`https://wrapped.tf/recap/${profileData?.enemies[section].enemy_id64}`} target="_blank">
                         {profileData?.steamInfo[profileData?.enemies[section].enemy_id64]?.name}
                       </a>
-                      <p className="text-sm  text-lightmode-secondary dark:text-darkmode-secondary">
+                      <p className="text-sm  text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary">
                         {profileData?.enemies[section].matches_played} matches
                       </p>
                     </div>
@@ -676,17 +676,17 @@ const Recap: React.FC = () => {
                       <div className="flex justify-center items-center md:gap-4">
                         {/* Wins */}
                         <div className="flex justify-center items-center md:flex-row-reverse md:gap-x-2">
-                          <div className="mr-2 md:hidden  text-lightmode-secondary dark:text-darkmode-secondary xl:text-[1.3vw] max-md:text-sm max-xl:text-[2.8vw]">W/L:</div>
-                          <div className="max-md:hidden  text-lightmode-secondary dark:text-darkmode-secondary xl:text-[1vw] max-xl:text-[2vw]">WINS</div>
-                          <div className="flex items-center text-lightmode-primary dark:text-darkmode-primary xl:text-[1.3vw] max-xl:text-[2.8vw] max-md:text-sm md:-mt-[0.5vw]">
+                          <div className="mr-2 md:hidden  text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary xl:text-[1.3vw] max-md:text-sm max-xl:text-[2.8vw]">W/L:</div>
+                          <div className="max-md:hidden  text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary xl:text-[1vw] max-xl:text-[2vw]">WINS</div>
+                          <div className="flex items-center text-lightmode-primary transition duration-500 dark:text-darkmode-primary xl:text-[1.3vw] max-xl:text-[2.8vw] max-md:text-sm md:-mt-[0.5vw]">
                             <span className="font-bold">{formatNumber(profileData?.enemies[section].wins)}</span>
                             <span className="md:hidden mx-1">/</span>
                           </div>
                         </div>
                         {/* Losses */}
                         <div className="flex justify-center items-center md:flex-row-reverse md:gap-x-2">
-                          <div className="max-md:hidden  text-lightmode-secondary dark:text-darkmode-secondary xl:text-[1vw] max-xl:text-[2vw]">LOSSES</div>
-                          <div className="flex items-center text-lightmode-primary dark:text-darkmode-primary xl:text-[1.3vw] max-xl:text-[2.8vw] max-md:text-sm md:-mt-[0.5vw]">
+                          <div className="max-md:hidden  text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary xl:text-[1vw] max-xl:text-[2vw]">LOSSES</div>
+                          <div className="flex items-center text-lightmode-primary transition duration-500 dark:text-darkmode-primary xl:text-[1.3vw] max-xl:text-[2.8vw] max-md:text-sm md:-mt-[0.5vw]">
                             <span className="font-bold">{formatNumber(profileData?.enemies[section].losses)}</span>
                           </div>
                         </div>
@@ -714,52 +714,52 @@ const Recap: React.FC = () => {
               </div>
             ))}
           </div>
-          <div className="h-[2px] w-full bg-lightmode-primary dark:bg-darkmode-primary rounded-sm"></div>
+          <div className="h-[2px] w-full bg-lightmode-primary transition duration-500 dark:bg-darkmode-primary rounded-sm"></div>
         </section>
       </div>
 
       {/* Playing Trends New Style */}
-      <div className="flex flex-col h-screen w-full snap-start items-center md:justify-center max-md:justify-start bg-topo-light bg-cover bg-center dark:bg-topo-dark bg-lightmode-background dark:bg-darkmode-background md:p-8 max-md:p-2 max-md:pt-20">
+      <div className="flex flex-col h-screen w-full snap-start items-center md:justify-center max-md:justify-start md:p-8 max-md:p-2 max-md:pt-20">
         <section aria-labelledby="Trends" className="max-xl:h-[70vh] max-h-full flex flex-col justify-center items-center  max-xl:w-full xl:w-1/2 xl:h-4/6 font-londrina">
           {/* Section Header */}
-          <div className="w-full h-fit flex items-baseline text-lightmode-primary dark:text-darkmode-primary font-extrabold">
+          <div className="w-full h-fit flex items-baseline text-lightmode-primary transition duration-500 dark:text-darkmode-primary font-extrabold">
             <h2 id="Trends" className="text-4xl mx-2">Playing Trends</h2>
-            <div className="h-[2px] flex-grow bg-lightmode-primary dark:bg-darkmode-primary rounded-sm"></div>
+            <div className="h-[2px] flex-grow bg-lightmode-primary transition duration-500 dark:bg-darkmode-primary rounded-sm"></div>
           </div>
-          <div className="relative my-2 md:p-3 max-md:px-2 flex w-full h-full backdrop-blur border-2 border-lightmode-border dark:border-darkmode-border rounded-tl-3xl rounded-br-3xl rounded-tr-lg rounded-bl-lg">
+          <div className="relative my-2 md:p-3 max-md:px-2 flex w-full h-full backdrop-blur border-2 border-lightmode-border transition duration-500 dark:border-darkmode-border rounded-tl-3xl rounded-br-3xl rounded-tr-lg rounded-bl-lg">
             <Bar data={data} options={options} />
           </div>
-          <div className="w-full h-fit flex text-lightmode-primary dark:text-darkmode-primary font-extrabold gap-2 items-center">
-            <div className="h-[2px] w-4 flex-auto bg-lightmode-primary dark:bg-darkmode-primary rounded-sm"></div>
-            {profileData?.dailyActivity.length !== 0 && <div className="text-lightmode-primary dark:text-darkmode-primary">On {profileData?.dailyActivity[0].day ? formatDate(profileData.dailyActivity[0].day) : "No date available"}, you played {profileData?.dailyActivity[0].matches_played} games, making it your busiest day.</div>}
-            <div className="h-[2px] w-4 flex-auto bg-lightmode-primary dark:bg-darkmode-primary rounded-sm"></div>
+          <div className="w-full h-fit flex text-lightmode-primary transition duration-500 dark:text-darkmode-primary font-extrabold gap-2 items-center">
+            <div className="h-[2px] w-4 flex-auto bg-lightmode-primary transition duration-500 dark:bg-darkmode-primary rounded-sm"></div>
+            {profileData?.dailyActivity.length !== 0 && <div className="text-lightmode-primary transition duration-500 dark:text-darkmode-primary">On {profileData?.dailyActivity[0].day ? formatDate(profileData.dailyActivity[0].day) : "No date available"}, you played {profileData?.dailyActivity[0].matches_played} games, making it your busiest day.</div>}
+            <div className="h-[2px] w-4 flex-auto bg-lightmode-primary transition duration-500 dark:bg-darkmode-primary rounded-sm"></div>
           </div>
         </section>
       </div>
 
       {/* Best Teammates & Enemies New Style */}
-      <div className="flex flex-col h-screen w-full snap-start items-center md:justify-center max-md:justify-start bg-topo-light bg-cover bg-center dark:bg-topo-dark bg-lightmode-background dark:bg-darkmode-background md:p-8 max-md:p-2 max-md:pt-20">
+      <div className="flex flex-col h-screen w-full snap-start items-center md:justify-center max-md:justify-start md:p-8 max-md:p-2 max-md:pt-20">
         <section aria-label="Best Winrate Players" className="max-xl:h-[70vh] max-h-full flex flex-col justify-center items-center max-xl:w-full xl:w-2/3 xl:h-4/6 font-londrina">
           {/* Section Header */}
-          <div className="w-full h-fit flex items-baseline text-lightmode-primary dark:text-darkmode-primary font-extrabold gap-4">
+          <div className="w-full h-fit flex items-baseline text-lightmode-primary transition duration-500 dark:text-darkmode-primary font-extrabold gap-4">
             <div className="flex w-full justify-center items-center">
-              <div className="h-[2px] flex-grow bg-lightmode-primary dark:bg-darkmode-primary rounded-sm"></div>
+              <div className="h-[2px] flex-grow bg-lightmode-primary transition duration-500 dark:bg-darkmode-primary rounded-sm"></div>
               <div className="text-4xl mx-2">Best Winrate With</div>
-              <div className="h-[2px] flex-grow bg-lightmode-primary dark:bg-darkmode-primary rounded-sm"></div>
+              <div className="h-[2px] flex-grow bg-lightmode-primary transition duration-500 dark:bg-darkmode-primary rounded-sm"></div>
             </div>
             <div className="flex w-full justify-center items-center max-md:hidden">
-              <div className="h-[2px] flex-grow bg-lightmode-primary dark:bg-darkmode-primary rounded-sm"></div>
+              <div className="h-[2px] flex-grow bg-lightmode-primary transition duration-500 dark:bg-darkmode-primary rounded-sm"></div>
               <div className="text-4xl mx-2">Best Winrate Against</div>
-              <div className="h-[2px] flex-grow bg-lightmode-primary dark:bg-darkmode-primary rounded-sm"></div>
+              <div className="h-[2px] flex-grow bg-lightmode-primary transition duration-500 dark:bg-darkmode-primary rounded-sm"></div>
             </div>
           </div>
 
           <div className="w-full h-full grid md:grid-cols-2 max-md:grid-rows-2 p-2">
               {/* Teammates */}
-              <div className="w-full h-full overflow-hidden grid grid-rows-3 p-2 xl:gap-3 max-xl:gap-2 md:border-r-2 border-lightmode-primary dark:border-darkmode-primary">
+              <div className="w-full h-full overflow-hidden grid grid-rows-3 p-2 xl:gap-3 max-xl:gap-2 md:border-r-2 border-lightmode-primary transition duration-500 dark:border-darkmode-primary">
                 {[0, 1, 2].map((section) => (
-                  <div key={section} className="relative md:p-3 max-md:px-2 flex w-full h-full backdrop-blur border-2 border-lightmode-border dark:border-darkmode-border rounded-tl-3xl rounded-br-3xl rounded-tr-lg rounded-bl-lg">
-                    <div className="absolute bottom-0 left-2 text-lightmode-primary dark:text-darkmode-primary opacity-50 ">{section+1}.</div>
+                  <div key={section} className="relative md:p-3 max-md:px-2 flex w-full h-full backdrop-blur border-2 border-lightmode-border transition duration-500 dark:border-darkmode-border rounded-tl-3xl rounded-br-3xl rounded-tr-lg rounded-bl-lg">
+                    <div className="absolute bottom-0 left-2 text-lightmode-primary transition duration-500 dark:text-darkmode-primary opacity-50 ">{section+1}.</div>
                     <div className="h-full w-fit flex items-center mr-2">
                       <img
                         loading="lazy"
@@ -772,10 +772,10 @@ const Recap: React.FC = () => {
                       {/* Player Title */}
                       <div className="w-full h-full">
                         <div className="h-full w-full text-left flex flex-col justify-center items-start">
-                          <a className="md:text-3xl w-full sm:text-2xl max-sm:text-lg font-semibold text-lightmode-primary dark:text-darkmode-primary -my-1 truncate overflow-hidden hover:underline" href={`https://wrapped.tf/recap/${profileData?.winningTeammates[section].teammate_id64}`} target="_blank">
+                          <a className="md:text-3xl w-full sm:text-2xl max-sm:text-lg font-semibold text-lightmode-primary transition duration-500 dark:text-darkmode-primary -my-1 truncate overflow-hidden hover:underline" href={`https://wrapped.tf/recap/${profileData?.winningTeammates[section].teammate_id64}`} target="_blank">
                             {profileData?.steamInfo[profileData?.winningTeammates[section].teammate_id64]?.name}
                           </a>
-                          <p className="text-sm  text-lightmode-secondary dark:text-darkmode-secondary">
+                          <p className="text-sm  text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary">
                             {profileData?.winningTeammates[section].matches_won + profileData?.winningTeammates[section].matches_lost} matches
                           </p>
                         </div>
@@ -786,17 +786,17 @@ const Recap: React.FC = () => {
                           <div className="flex justify-center items-center md:gap-4">
                             {/* Wins */}
                             <div className="flex justify-center items-center md:flex-col ">
-                              <div className="mr-2 md:hidden  text-lightmode-secondary dark:text-darkmode-secondary xl:text-[1.3vw] max-md:text-sm max-xl:text-[2.8vw]">W/L:</div>
-                              <div className="max-md:hidden  text-lightmode-secondary dark:text-darkmode-secondary xl:text-[1vw] max-xl:text-[2vw]">WINS</div>
-                              <div className="flex items-center text-lightmode-primary dark:text-darkmode-primary xl:text-[1.3vw] max-xl:text-[2.8vw] max-md:text-sm md:-mt-[0.5vw]">
+                              <div className="mr-2 md:hidden  text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary xl:text-[1.3vw] max-md:text-sm max-xl:text-[2.8vw]">W/L:</div>
+                              <div className="max-md:hidden  text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary xl:text-[1vw] max-xl:text-[2vw]">WINS</div>
+                              <div className="flex items-center text-lightmode-primary transition duration-500 dark:text-darkmode-primary xl:text-[1.3vw] max-xl:text-[2.8vw] max-md:text-sm md:-mt-[0.5vw]">
                                 <span className="font-bold">{formatNumber(profileData?.winningTeammates[section].matches_won)}</span>
                                 <span className="md:hidden mx-1">/</span>
                               </div>
                             </div>
                             {/* Losses */}
                             <div className="flex justify-center items-center md:flex-col">
-                              <div className="max-md:hidden  text-lightmode-secondary dark:text-darkmode-secondary xl:text-[1vw] max-xl:text-[2vw]">LOSSES</div>
-                              <div className="flex items-center text-lightmode-primary dark:text-darkmode-primary xl:text-[1.3vw] max-xl:text-[2.8vw] max-md:text-sm md:-mt-[0.5vw]">
+                              <div className="max-md:hidden  text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary xl:text-[1vw] max-xl:text-[2vw]">LOSSES</div>
+                              <div className="flex items-center text-lightmode-primary transition duration-500 dark:text-darkmode-primary xl:text-[1.3vw] max-xl:text-[2.8vw] max-md:text-sm md:-mt-[0.5vw]">
                                 <span className="font-bold">{formatNumber(profileData?.winningTeammates[section].matches_lost)}</span>
                               </div>
                             </div>
@@ -825,16 +825,16 @@ const Recap: React.FC = () => {
                 ))}
               </div>
                 <div>
-                  <div className="flex w-full justify-center items-center md:hidden text-lightmode-primary dark:text-darkmode-primary">
-                    <div className="h-[2px] flex-grow bg-lightmode-primary dark:bg-darkmode-primary rounded-sm"></div>
+                  <div className="flex w-full justify-center items-center md:hidden text-lightmode-primary transition duration-500 dark:text-darkmode-primary">
+                    <div className="h-[2px] flex-grow bg-lightmode-primary transition duration-500 dark:bg-darkmode-primary rounded-sm"></div>
                     <div className="text-4xl mx-2">Best Winrate Against</div>
-                    <div className="h-[2px] flex-grow bg-lightmode-primary dark:bg-darkmode-primary rounded-sm"></div>
+                    <div className="h-[2px] flex-grow bg-lightmode-primary transition duration-500 dark:bg-darkmode-primary rounded-sm"></div>
                   </div>
                   {/* Enemies */}
               <div className="w-full h-full overflow-hidden grid grid-rows-3 p-2 xl:gap-3 max-xl:gap-2">
                 {[0, 1, 2].map((section) => (
-                  <div key={section} className="relative md:p-3 max-md:px-2 flex w-full h-full backdrop-blur border-2 border-lightmode-border dark:border-darkmode-border rounded-tl-3xl rounded-br-3xl rounded-tr-lg rounded-bl-lg">
-                    <div className="absolute bottom-0 left-2 text-lightmode-primary dark:text-darkmode-primary opacity-50 ">{section+1}.</div>
+                  <div key={section} className="relative md:p-3 max-md:px-2 flex w-full h-full backdrop-blur border-2 border-lightmode-border transition duration-500 dark:border-darkmode-border rounded-tl-3xl rounded-br-3xl rounded-tr-lg rounded-bl-lg">
+                    <div className="absolute bottom-0 left-2 text-lightmode-primary transition duration-500 dark:text-darkmode-primary opacity-50 ">{section+1}.</div>
                     <div className="h-full w-fit flex items-center mr-2">
                       <img
                         loading="lazy"
@@ -847,10 +847,10 @@ const Recap: React.FC = () => {
                       {/* Map Title */}
                       <div className="w-full h-full">
                         <div className="h-full w-full text-left flex flex-col justify-center items-start">
-                          <a className="md:text-3xl w-full sm:text-2xl max-sm:text-lg font-semibold text-lightmode-primary dark:text-darkmode-primary -my-1 truncate overflow-hidden hover:underline" href={`https://wrapped.tf/recap/${profileData?.winningEnemies[section].enemy_id64}`} target="_blank">
+                          <a className="md:text-3xl w-full sm:text-2xl max-sm:text-lg font-semibold text-lightmode-primary transition duration-500 dark:text-darkmode-primary -my-1 truncate overflow-hidden hover:underline" href={`https://wrapped.tf/recap/${profileData?.winningEnemies[section].enemy_id64}`} target="_blank">
                             {profileData?.steamInfo[profileData?.winningEnemies[section].enemy_id64]?.name}
                           </a>
-                          <p className="text-sm  text-lightmode-secondary dark:text-darkmode-secondary">
+                          <p className="text-sm  text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary">
                             {profileData?.winningEnemies[section].matches_won + profileData?.winningEnemies[section].matches_lost} matches
                           </p>
                         </div>
@@ -861,17 +861,17 @@ const Recap: React.FC = () => {
                           <div className="flex justify-center items-center md:gap-4">
                             {/* Wins */}
                             <div className="flex justify-center items-center md:flex-col ">
-                              <div className="mr-2 md:hidden  text-lightmode-secondary dark:text-darkmode-secondary xl:text-[1.3vw] max-md:text-sm max-xl:text-[2.8vw]">W/L:</div>
-                              <div className="max-md:hidden  text-lightmode-secondary dark:text-darkmode-secondary xl:text-[1vw] max-xl:text-[2vw]">WINS</div>
-                              <div className="flex items-center text-lightmode-primary dark:text-darkmode-primary xl:text-[1.3vw] max-xl:text-[2.8vw] max-md:text-sm md:-mt-[0.5vw]">
+                              <div className="mr-2 md:hidden  text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary xl:text-[1.3vw] max-md:text-sm max-xl:text-[2.8vw]">W/L:</div>
+                              <div className="max-md:hidden  text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary xl:text-[1vw] max-xl:text-[2vw]">WINS</div>
+                              <div className="flex items-center text-lightmode-primary transition duration-500 dark:text-darkmode-primary xl:text-[1.3vw] max-xl:text-[2.8vw] max-md:text-sm md:-mt-[0.5vw]">
                                 <span className="font-bold">{formatNumber(profileData?.winningEnemies[section].matches_won)}</span>
                                 <span className="md:hidden mx-1">/</span>
                               </div>
                             </div>
                             {/* Losses */}
                             <div className="flex justify-center items-center md:flex-col">
-                              <div className="max-md:hidden  text-lightmode-secondary dark:text-darkmode-secondary xl:text-[1vw] max-xl:text-[2vw]">LOSSES</div>
-                              <div className="flex items-center text-lightmode-primary dark:text-darkmode-primary xl:text-[1.3vw] max-xl:text-[2.8vw] max-md:text-sm md:-mt-[0.5vw]">
+                              <div className="max-md:hidden  text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary xl:text-[1vw] max-xl:text-[2vw]">LOSSES</div>
+                              <div className="flex items-center text-lightmode-primary transition duration-500 dark:text-darkmode-primary xl:text-[1.3vw] max-xl:text-[2.8vw] max-md:text-sm md:-mt-[0.5vw]">
                                 <span className="font-bold">{formatNumber(profileData?.winningEnemies[section].matches_lost)}</span>
                               </div>
                             </div>
@@ -903,33 +903,33 @@ const Recap: React.FC = () => {
               
           </div>
 
-          <div className="h-[2px] w-full bg-lightmode-primary dark:bg-darkmode-primary rounded-sm"></div>
+          <div className="h-[2px] w-full bg-lightmode-primary transition duration-500 dark:bg-darkmode-primary rounded-sm"></div>
         </section>
       </div>
 
       {/* Worst Teammates & Enemies New Style */}
-      <div className="flex flex-col h-screen w-full snap-start items-center md:justify-center max-md:justify-start bg-topo-light bg-cover bg-center dark:bg-topo-dark bg-lightmode-background dark:bg-darkmode-background md:p-8 max-md:p-2 max-md:pt-20">
+      <div className="flex flex-col h-screen w-full snap-start items-center md:justify-center max-md:justify-start md:p-8 max-md:p-2 max-md:pt-20">
         <section aria-label="Worst Winrate Players" className="max-xl:h-[70vh] max-h-full flex flex-col justify-center items-center  max-xl:w-full xl:w-2/3 xl:h-4/6 font-londrina">
           {/* Section Header */}
-          <div className="w-full h-fit flex items-baseline text-lightmode-primary dark:text-darkmode-primary font-extrabold gap-4">
+          <div className="w-full h-fit flex items-baseline text-lightmode-primary transition duration-500 dark:text-darkmode-primary font-extrabold gap-4">
             <div className="flex w-full justify-center items-center">
-              <div className="h-[2px] flex-grow bg-lightmode-primary dark:bg-darkmode-primary rounded-sm"></div>
+              <div className="h-[2px] flex-grow bg-lightmode-primary transition duration-500 dark:bg-darkmode-primary rounded-sm"></div>
               <div className="text-4xl mx-2">Worst Winrate With</div>
-              <div className="h-[2px] flex-grow bg-lightmode-primary dark:bg-darkmode-primary rounded-sm"></div>
+              <div className="h-[2px] flex-grow bg-lightmode-primary transition duration-500 dark:bg-darkmode-primary rounded-sm"></div>
             </div>
             <div className="flex w-full justify-center items-center max-md:hidden">
-              <div className="h-[2px] flex-grow bg-lightmode-primary dark:bg-darkmode-primary rounded-sm"></div>
+              <div className="h-[2px] flex-grow bg-lightmode-primary transition duration-500 dark:bg-darkmode-primary rounded-sm"></div>
               <div className="text-4xl mx-2">Worst Winrate Against</div>
-              <div className="h-[2px] flex-grow bg-lightmode-primary dark:bg-darkmode-primary rounded-sm"></div>
+              <div className="h-[2px] flex-grow bg-lightmode-primary transition duration-500 dark:bg-darkmode-primary rounded-sm"></div>
             </div>
           </div>
 
             <div className="w-full h-full grid md:grid-cols-2 max-md:grid-rows-2 p-2">
               {/* Teammates */}
-              <div className="w-full h-full overflow-hidden grid grid-rows-3 p-2 xl:gap-3 max-xl:gap-2 md:border-r-2 border-lightmode-primary dark:border-darkmode-primary">
+              <div className="w-full h-full overflow-hidden grid grid-rows-3 p-2 xl:gap-3 max-xl:gap-2 md:border-r-2 border-lightmode-primary transition duration-500 dark:border-darkmode-primary">
                 {[0, 1, 2].map((section) => (
-                  <div key={section} className="relative md:p-3 max-md:px-2 flex w-full h-full backdrop-blur border-2 border-lightmode-border dark:border-darkmode-border rounded-tl-3xl rounded-br-3xl rounded-tr-lg rounded-bl-lg">
-                    <div className="absolute bottom-0 left-2 text-lightmode-primary dark:text-darkmode-primary opacity-50 ">{section+1}.</div>
+                  <div key={section} className="relative md:p-3 max-md:px-2 flex w-full h-full backdrop-blur border-2 border-lightmode-border transition duration-500 dark:border-darkmode-border rounded-tl-3xl rounded-br-3xl rounded-tr-lg rounded-bl-lg">
+                    <div className="absolute bottom-0 left-2 text-lightmode-primary transition duration-500 dark:text-darkmode-primary opacity-50 ">{section+1}.</div>
                     <div className="h-full w-fit flex items-center mr-2">
                       <img
                         loading="lazy"
@@ -942,10 +942,10 @@ const Recap: React.FC = () => {
                       {/* Map Title */}
                       <div className="w-full h-full">
                         <div className="h-full w-full text-left flex flex-col justify-center items-start">
-                          <a className="md:text-3xl w-full sm:text-2xl max-sm:text-lg font-semibold text-lightmode-primary dark:text-darkmode-primary -my-1 truncate overflow-hidden hover:underline" href={`https://wrapped.tf/recap/${profileData?.losingTeammates[section].teammate_id64}`} target="_blank">
+                          <a className="md:text-3xl w-full sm:text-2xl max-sm:text-lg font-semibold text-lightmode-primary transition duration-500 dark:text-darkmode-primary -my-1 truncate overflow-hidden hover:underline" href={`https://wrapped.tf/recap/${profileData?.losingTeammates[section].teammate_id64}`} target="_blank">
                             {profileData?.steamInfo[profileData?.losingTeammates[section].teammate_id64]?.name}
                           </a>
-                          <p className="text-sm  text-lightmode-secondary dark:text-darkmode-secondary">
+                          <p className="text-sm  text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary">
                             {profileData?.losingTeammates[section].matches_won + profileData?.losingTeammates[section].matches_lost} matches
                           </p>
                         </div>
@@ -956,17 +956,17 @@ const Recap: React.FC = () => {
                           <div className="flex justify-center items-center md:gap-4">
                             {/* Wins */}
                             <div className="flex justify-center items-center md:flex-col ">
-                              <div className="mr-2 md:hidden  text-lightmode-secondary dark:text-darkmode-secondary xl:text-[1.3vw] max-md:text-sm max-xl:text-[2.8vw]">W/L:</div>
-                              <div className="max-md:hidden  text-lightmode-secondary dark:text-darkmode-secondary xl:text-[1vw] max-xl:text-[2vw]">WINS</div>
-                              <div className="flex items-center text-lightmode-primary dark:text-darkmode-primary xl:text-[1.3vw] max-xl:text-[2.8vw] max-md:text-sm md:-mt-[0.5vw]">
+                              <div className="mr-2 md:hidden  text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary xl:text-[1.3vw] max-md:text-sm max-xl:text-[2.8vw]">W/L:</div>
+                              <div className="max-md:hidden  text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary xl:text-[1vw] max-xl:text-[2vw]">WINS</div>
+                              <div className="flex items-center text-lightmode-primary transition duration-500 dark:text-darkmode-primary xl:text-[1.3vw] max-xl:text-[2.8vw] max-md:text-sm md:-mt-[0.5vw]">
                                 <span className="font-bold">{formatNumber(profileData?.losingTeammates[section].matches_won)}</span>
                                 <span className="md:hidden mx-1">/</span>
                               </div>
                             </div>
                             {/* Losses */}
                             <div className="flex justify-center items-center md:flex-col">
-                              <div className="max-md:hidden  text-lightmode-secondary dark:text-darkmode-secondary xl:text-[1vw] max-xl:text-[2vw]">LOSSES</div>
-                              <div className="flex items-center text-lightmode-primary dark:text-darkmode-primary xl:text-[1.3vw] max-xl:text-[2.8vw] max-md:text-sm md:-mt-[0.5vw]">
+                              <div className="max-md:hidden  text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary xl:text-[1vw] max-xl:text-[2vw]">LOSSES</div>
+                              <div className="flex items-center text-lightmode-primary transition duration-500 dark:text-darkmode-primary xl:text-[1.3vw] max-xl:text-[2.8vw] max-md:text-sm md:-mt-[0.5vw]">
                                 <span className="font-bold">{formatNumber(profileData?.losingTeammates[section].matches_lost)}</span>
                               </div>
                             </div>
@@ -995,16 +995,16 @@ const Recap: React.FC = () => {
                 ))}
               </div>
                 <div>
-                  <div className="flex w-full justify-center items-center md:hidden text-lightmode-primary dark:text-darkmode-primary">
-                    <div className="h-[2px] flex-grow bg-lightmode-primary dark:bg-darkmode-primary rounded-sm"></div>
+                  <div className="flex w-full justify-center items-center md:hidden text-lightmode-primary transition duration-500 dark:text-darkmode-primary">
+                    <div className="h-[2px] flex-grow bg-lightmode-primary transition duration-500 dark:bg-darkmode-primary rounded-sm"></div>
                     <div className="text-4xl mx-2">Worst Winrate Against</div>
-                    <div className="h-[2px] flex-grow bg-lightmode-primary dark:bg-darkmode-primary rounded-sm"></div>
+                    <div className="h-[2px] flex-grow bg-lightmode-primary transition duration-500 dark:bg-darkmode-primary rounded-sm"></div>
                   </div>
                   {/* Enemies */}
               <div className="w-full h-full overflow-hidden grid grid-rows-3 p-2 xl:gap-3 max-xl:gap-2">
                 {[0, 1, 2].map((section) => (
-                  <div key={section} className="relative md:p-3 max-md:px-2 flex w-full h-full backdrop-blur border-2 border-lightmode-border dark:border-darkmode-border rounded-tl-3xl rounded-br-3xl rounded-tr-lg rounded-bl-lg">
-                    <div className="absolute bottom-0 left-2 text-lightmode-primary dark:text-darkmode-primary opacity-50 ">{section+1}.</div>
+                  <div key={section} className="relative md:p-3 max-md:px-2 flex w-full h-full backdrop-blur border-2 border-lightmode-border transition duration-500 dark:border-darkmode-border rounded-tl-3xl rounded-br-3xl rounded-tr-lg rounded-bl-lg">
+                    <div className="absolute bottom-0 left-2 text-lightmode-primary transition duration-500 dark:text-darkmode-primary opacity-50 ">{section+1}.</div>
                     <div className="h-full w-fit flex items-center mr-2">
                       <img
                         loading="lazy"
@@ -1017,10 +1017,10 @@ const Recap: React.FC = () => {
                       {/* Map Title */}
                       <div className="w-full h-full">
                         <div className="h-full w-full text-left flex flex-col justify-center items-start">
-                          <a className="md:text-3xl w-full sm:text-2xl max-sm:text-lg font-semibold text-lightmode-primary dark:text-darkmode-primary -my-1 truncate overflow-hidden hover:underline" href={`https://wrapped.tf/recap/${profileData?.losingEnemies[section].enemy_id64}`} target="_blank">
+                          <a className="md:text-3xl w-full sm:text-2xl max-sm:text-lg font-semibold text-lightmode-primary transition duration-500 dark:text-darkmode-primary -my-1 truncate overflow-hidden hover:underline" href={`https://wrapped.tf/recap/${profileData?.losingEnemies[section].enemy_id64}`} target="_blank">
                             {profileData?.steamInfo[profileData?.losingEnemies[section].enemy_id64]?.name}
                           </a>
-                          <p className="text-sm  text-lightmode-secondary dark:text-darkmode-secondary">
+                          <p className="text-sm  text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary">
                             {profileData?.losingEnemies[section].matches_won + profileData?.losingEnemies[section].matches_lost} matches
                           </p>
                         </div>
@@ -1031,17 +1031,17 @@ const Recap: React.FC = () => {
                           <div className="flex justify-center items-center md:gap-4">
                             {/* Wins */}
                             <div className="flex justify-center items-center md:flex-col ">
-                              <div className="mr-2 md:hidden  text-lightmode-secondary dark:text-darkmode-secondary xl:text-[1.3vw] max-md:text-sm max-xl:text-[2.8vw]">W/L:</div>
-                              <div className="max-md:hidden  text-lightmode-secondary dark:text-darkmode-secondary xl:text-[1vw] max-xl:text-[2vw]">WINS</div>
-                              <div className="flex items-center text-lightmode-primary dark:text-darkmode-primary xl:text-[1.3vw] max-xl:text-[2.8vw] max-md:text-sm md:-mt-[0.5vw]">
+                              <div className="mr-2 md:hidden  text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary xl:text-[1.3vw] max-md:text-sm max-xl:text-[2.8vw]">W/L:</div>
+                              <div className="max-md:hidden  text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary xl:text-[1vw] max-xl:text-[2vw]">WINS</div>
+                              <div className="flex items-center text-lightmode-primary transition duration-500 dark:text-darkmode-primary xl:text-[1.3vw] max-xl:text-[2.8vw] max-md:text-sm md:-mt-[0.5vw]">
                                 <span className="font-bold">{formatNumber(profileData?.losingEnemies[section].matches_won)}</span>
                                 <span className="md:hidden mx-1">/</span>
                               </div>
                             </div>
                             {/* Losses */}
                             <div className="flex justify-center items-center md:flex-col">
-                              <div className="max-md:hidden  text-lightmode-secondary dark:text-darkmode-secondary xl:text-[1vw] max-xl:text-[2vw]">LOSSES</div>
-                              <div className="flex items-center text-lightmode-primary dark:text-darkmode-primary xl:text-[1.3vw] max-xl:text-[2.8vw] max-md:text-sm md:-mt-[0.5vw]">
+                              <div className="max-md:hidden  text-lightmode-secondary transition duration-500 dark:text-darkmode-secondary xl:text-[1vw] max-xl:text-[2vw]">LOSSES</div>
+                              <div className="flex items-center text-lightmode-primary transition duration-500 dark:text-darkmode-primary xl:text-[1.3vw] max-xl:text-[2.8vw] max-md:text-sm md:-mt-[0.5vw]">
                                 <span className="font-bold">{formatNumber(profileData?.losingEnemies[section].matches_lost)}</span>
                               </div>
                             </div>
@@ -1071,15 +1071,15 @@ const Recap: React.FC = () => {
               </div>
                 </div>
             </div>
-          <div className="h-[2px] w-full bg-lightmode-primary dark:bg-darkmode-primary rounded-sm"></div>
+          <div className="h-[2px] w-full bg-lightmode-primary transition duration-500 dark:bg-darkmode-primary rounded-sm"></div>
         </section>
       </div>
       
       {/* Share */}
-      <div className="flex flex-col h-screen w-full snap-start items-center justify-center bg-topo-light bg-cover bg-center dark:bg-topo-dark font-londrina bg-lightmode-background dark:bg-darkmode-background md:p-8 max-md:p-3">
+      <div className="flex flex-col h-screen w-full snap-start items-center justify-center md:p-8 max-md:p-3">
         <section aria-labelledby="Share" className="max-xl:h-[70vh] max-h-full flex flex-col justify-center items-center  max-xl:w-full xl:w-2/3 xl:h-4/6 max-md:mb-20">
           <div className="w-full h-full md:h-1/2 md:w-1/2 flex flex-col justify-center items-center p-2">
-            <div className="w-full h-fit flex justify-center items-baseline text-lightmode-primary dark:text-darkmode-primary font-extrabold gap-4">
+            <div className="w-full h-fit flex justify-center items-baseline text-lightmode-primary transition duration-500 dark:text-darkmode-primary font-extrabold gap-4">
               <h2 id="Share" className="text-4xl mx-2 mb-3">Download & Share</h2></div>
               <div className="flex flex-col items-center justify-center w-fit h-fit">
                 {/* Recap Card */}


### PR DESCRIPTION
Makes the recap background static, rather than having a copy for every section that scrolls with the page. Makes scrolling feel smoother. Also added smooth dark mode fading to all elements with a dark designation.